### PR TITLE
add search filter in DEFAULT_FILTER_BACKENDS and use it on users

### DIFF
--- a/blitz_api/settings.py
+++ b/blitz_api/settings.py
@@ -239,6 +239,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_FILTER_BACKENDS': (
         'rest_framework_filters.backends.DjangoFilterBackend',
+        'rest_framework.filters.SearchFilter',
         'rest_framework.filters.OrderingFilter'
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.'

--- a/blitz_api/tests/tests_view_Users.py
+++ b/blitz_api/tests/tests_view_Users.py
@@ -669,6 +669,61 @@ class UsersTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_list_users_with_search(self):
+        """
+        Ensure we can list all users.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get(reverse('user-list') + '?search=chuck')
+        self.assertEqual(json.loads(response.content)['count'], 1)
+
+        # Users are ordered alphabetically by email
+        first_user = json.loads(response.content)['results'][0]
+        self.assertEqual(first_user['email'], self.admin.email)
+
+        # Check the system doesn't return attributes not expected
+        attributes = [
+            'id',
+            'url',
+            'email',
+            'first_name',
+            'last_name',
+            'is_active',
+            'phone',
+            'other_phone',
+            'is_superuser',
+            'is_staff',
+            'university',
+            'last_login',
+            'date_joined',
+            'academic_level',
+            'academic_field',
+            'gender',
+            'birthdate',
+            'groups',
+            'user_permissions',
+            'tickets',
+            'membership',
+            'membership_end',
+        ]
+        for key in first_user.keys():
+            self.assertTrue(
+                key in attributes,
+                'Attribute "{0}" is not expected but is '
+                'returned by the system.'.format(key)
+            )
+            attributes.remove(key)
+
+        # Ensure the system returns all expected attributes
+        self.assertTrue(
+            len(attributes) == 0,
+            'The system failed to return some '
+            'attributes : {0}'.format(attributes)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_list_users_without_authenticate(self):
         """
         Ensure we can't list users without authentication.

--- a/blitz_api/views.py
+++ b/blitz_api/views.py
@@ -9,7 +9,7 @@ from django.http import Http404, HttpResponse
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
-from rest_framework import status, viewsets, mixins
+from rest_framework import status, viewsets, mixins, filters
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.views import APIView
@@ -69,6 +69,7 @@ class UserViewSet(viewsets.ModelViewSet):
         'groups': '__all__',
         'user_permissions': '__all__'
     }
+    search_fields = ('first_name', 'last_name', 'email')
     ordering = ('email',)
 
     @action(detail=False, permission_classes=[IsAdminUser])


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Features
| Tickets (_issues_) concerned               | None

---

##### What have you changed ?
Allow customer to search user by `email`, `first_name` and or `last_name` all by the same queryparam `search`

##### How did you change it ?
I found an existing type of backend filter in Django Rest Framework :
https://www.django-rest-framework.org/api-guide/filtering/#searchfilter

##### Is there a special consideration?
No

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [x] My additions are I18N
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 -  [x] I added or modified the documentation