### PR TITLE
add billing_price to timeslot

### DIFF
--- a/store/serializers.py
+++ b/store/serializers.py
@@ -548,7 +548,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
                     timeslot = reservation_orderline.content_object
                     reservations = timeslot.reservations.filter(is_active=True)
                     reserved = reservations.count()
-                    if timeslot.price > user.tickets:
+                    if timeslot.billing_price > user.tickets:
                         raise serializers.ValidationError({
                             'non_field_errors': [_(
                                 "You don't have enough tickets to make this "

--- a/store/tests/tests_viewset_Coupon.py
+++ b/store/tests/tests_viewset_Coupon.py
@@ -1129,6 +1129,7 @@ class CouponTests(APITestCase):
                     'has_shared_rooms': True,
                 }],
                 "applicable_timeslots": [{
+                    'billing_price': 1.0,
                     'end_time': '2130-01-15T12:00:00-05:00',
                     'id': self.period.id,
                     'period': 'http://testserver/periods/' +
@@ -1345,6 +1346,7 @@ class CouponTests(APITestCase):
                 'has_shared_rooms': True,
             }],
             "applicable_timeslots": [{
+                'billing_price': 1.0,
                 'end_time': '2130-01-15T12:00:00-05:00',
                 'id': self.period.id,
                 'period': 'http://testserver/periods/' + str(self.period.id),

--- a/workplace/models.py
+++ b/workplace/models.py
@@ -198,6 +198,13 @@ class TimeSlot(SafeDeleteModel):
     def __str__(self):
         return str(self.start_time) + " - " + str(self.end_time)
 
+    @property
+    def billing_price(self):
+        if self.price:
+            return self.price
+        else:
+            return self.period.price
+
 
 class Reservation(SafeDeleteModel):
     """Represents a user registration to a TimeSlot"""

--- a/workplace/serializers.py
+++ b/workplace/serializers.py
@@ -283,6 +283,7 @@ class PeriodSerializer(serializers.HyperlinkedModelSerializer):
 
 class TimeSlotSerializer(serializers.HyperlinkedModelSerializer):
     id = serializers.ReadOnlyField()
+    billing_price = serializers.ReadOnlyField()
     places_remaining = serializers.SerializerMethodField()
     reservations = serializers.SerializerMethodField()
     reservations_canceled = serializers.SerializerMethodField()

--- a/workplace/tests/tests_model_TimeSlot.py
+++ b/workplace/tests/tests_model_TimeSlot.py
@@ -46,3 +46,39 @@ class TimeSlotTests(APITestCase):
             time_slot.__str__(),
             str(time_slot.start_time) + " - " + str(time_slot.end_time)
         )
+
+    def test_billing_price(self):
+        """
+        Ensure we get the price attribute if it is not None when calling
+        get_price_or_default()
+        """
+
+        time_slot = TimeSlot.objects.create(
+            name="random_time_slot",
+            period=self.period,
+            price=1,
+            start_time=timezone.now(),
+            end_time=timezone.now() + timedelta(hours=4),
+        )
+
+        # For this test to make sense, the period price and the timeslot
+        # price must not be equal
+        self.assertNotEqual(self.period.price, time_slot.price)
+
+        self.assertEqual(time_slot.billing_price, time_slot.price)
+
+    def test_billing_price__price_none(self):
+        """
+        Ensure we get the period's price if the price attribute is None when
+        calling get_price_or_default()
+        """
+
+        time_slot = TimeSlot.objects.create(
+            name="random_time_slot",
+            period=self.period,
+            price=None,
+            start_time=timezone.now(),
+            end_time=timezone.now() + timedelta(hours=4),
+        )
+
+        self.assertEqual(time_slot.billing_price, self.period.price)

--- a/workplace/tests/tests_viewset_TimeSlot.py
+++ b/workplace/tests/tests_viewset_TimeSlot.py
@@ -89,7 +89,7 @@ class TimeSlotTests(APITestCase):
         cls.time_slot_active = TimeSlot.objects.create(
             name="evening_time_slot_active",
             period=cls.period_active,
-            price=3,
+            price=None,
             start_time=LOCAL_TIMEZONE.localize(datetime(2130, 1, 15, 18)),
             end_time=LOCAL_TIMEZONE.localize(datetime(2130, 1, 15, 22)),
         )
@@ -121,6 +121,7 @@ class TimeSlotTests(APITestCase):
         )
 
         content = {
+            'billing_price': 10,
             'end_time': data['end_time'].isoformat(),
             'price': '10.00',
             'places_remaining': 0,
@@ -170,6 +171,7 @@ class TimeSlotTests(APITestCase):
         del response_data['url']
 
         content = {
+            'billing_price': 3,
             'end_time': data['end_time'].isoformat(),
             'price': '3.00',
             'places_remaining': 40,
@@ -494,6 +496,7 @@ class TimeSlotTests(APITestCase):
             'id': self.time_slot_active.id,
             'end_time': data['end_time'].isoformat(),
             'price': '10.00',
+            'billing_price': 10,
             'places_remaining': 40,
             'reservations': [],
             'reservations_canceled': [],
@@ -571,6 +574,7 @@ class TimeSlotTests(APITestCase):
             'id': self.time_slot.id,
             'end_time': data['end_time'].isoformat(),
             'price': '10.00',
+            'billing_price': 10.00,
             'places_remaining': 40,
             'reservations': [],
             'reservations_canceled': [
@@ -644,6 +648,7 @@ class TimeSlotTests(APITestCase):
             'id': self.time_slot.id,
             'end_time': response_data['end_time'],
             'price': '1000.00',
+            'billing_price': 1000,
             'places_remaining': 38,
             'reservations': [
                 f'http://testserver/reservations/{self.reservation_admin.id}',
@@ -813,6 +818,7 @@ class TimeSlotTests(APITestCase):
             'id': self.time_slot.id,
             'end_time': response_data['end_time'],
             'price': '1000.00',
+            'billing_price': 1000,
             'places_remaining': 40,
             'reservations': [],
             'reservations_canceled': [
@@ -910,6 +916,7 @@ class TimeSlotTests(APITestCase):
             'id': self.time_slot.id,
             'end_time': response_data['end_time'],
             'price': '1000.00',
+            'billing_price': 1000,
             'places_remaining': 40,
             'reservations': [],
             'reservations_canceled': [
@@ -1115,7 +1122,8 @@ class TimeSlotTests(APITestCase):
             'results': [{
                 'id': self.time_slot_active.id,
                 'end_time': data['results'][0]['end_time'],
-                'price': '3.00',
+                'price': None,
+                'billing_price': 3,
                 'places_remaining': 40,
                 'reservations': [],
                 'reservations_canceled': [],
@@ -1177,6 +1185,7 @@ class TimeSlotTests(APITestCase):
                 'end_time': data['results'][0]['end_time'],
                 'period': f'http://testserver/periods/{self.period.id}',
                 'price': '3.00',
+                'billing_price': 3.0,
                 'places_remaining': 38,
                 'reservations': [
                     f'http://testserver/reservations/'
@@ -1208,7 +1217,8 @@ class TimeSlotTests(APITestCase):
             }, {
                 'id': self.time_slot_active.id,
                 'end_time': data['results'][1]['end_time'],
-                'price': '3.00',
+                'price': None,
+                'billing_price': 3.0,
                 'places_remaining': 40,
                 'reservations': [],
                 'reservations_canceled': [],
@@ -1292,6 +1302,7 @@ class TimeSlotTests(APITestCase):
                 ],
                 'reservations_canceled': [],
                 'price': '3.00',
+                "billing_price": 3,
                 'start_time': self.time_slot.start_time.isoformat(),
                 'url': f'http://testserver/time_slots/{self.time_slot.id}',
                 "workplace": {
@@ -1369,7 +1380,8 @@ class TimeSlotTests(APITestCase):
         content = {
             'id': self.time_slot_active.id,
             'end_time': self.time_slot_active.end_time.isoformat(),
-            'price': '3.00',
+            'price': None,
+            'billing_price': 3,
             'places_remaining': 40,
             'reservations': [],
             'reservations_canceled': [],
@@ -1444,6 +1456,7 @@ class TimeSlotTests(APITestCase):
             'end_time': data['end_time'],
             'period': f'http://testserver/periods/{self.period.id}',
             'price': '3.00',
+            'billing_price': 3,
             'places_remaining': 38,
             'reservations': [
                 f'http://testserver/reservations/{self.reservation_admin.id}',


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | [Fix]
| Tickets (_issues_) concerned               | [https://fjnr-inc.atlassian.net/jira/software/projects/TV/boards/2?selectedIssue=TV-194]

---

##### What have you changed ?
add @property billing_price to timeslot model  

##### How did you change it ?
...

##### Is there a special consideration?
I  noticed that if I put a price of more than one to a timeslot, the correct amount will be displayed on the right of the screen, but only one ticket will be substracted when doing the transaction. I did not fix this since it is not part of the ticket. It is not a short term problem since all the tickets have a cost of one, but we may consider adding it to the backlog.

Verification :
 -  [ ] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [ ] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [ ] My additions are I18N
 -  [X] This Pull-Request fully meets the requirements defined in the issue
 -  [X] I added or modified the attached tests
 -  [ ] I added or modified the documentation