### PR TITLE
fix error message on internationalized fields in retirement and workplace

### DIFF
--- a/blitz_api/services.py
+++ b/blitz_api/services.py
@@ -84,11 +84,11 @@ def check_if_translated_field(field_name, data_dict):
     return False
 
 
-def getMessageTranslate(field_name, data_dict, both_required=False):
+def getMessageTranslate(field_name, data_dict, only_one_required=False):
     err = {}
     messageError = _("This field is required.")
     err[field_name] = messageError
-    if both_required:
+    if only_one_required:
         messageError = _(
             "One of the two fields %(field)s must be completed."
         ) % {'field': field_name}

--- a/retirement/serializers.py
+++ b/retirement/serializers.py
@@ -21,7 +21,8 @@ from rest_framework.validators import UniqueValidator
 
 from blitz_api.serializers import UserSerializer
 from blitz_api.services import (check_if_translated_field,
-                                remove_translation_fields)
+                                remove_translation_fields,
+                                getMessageTranslate)
 from store.exceptions import PaymentAPIError
 from store.models import Order, OrderLine, PaymentProfile, Refund
 from store.services import (charge_payment,
@@ -127,17 +128,17 @@ class RetirementSerializer(serializers.HyperlinkedModelSerializer):
     def validate(self, attr):
         err = {}
         if not check_if_translated_field('name', attr):
-            err['name'] = _("This field is required.")
+            err.update(getMessageTranslate('name', attr, True))
         if not check_if_translated_field('details', attr):
-            err['details'] = _("This field is required.")
+            err.update(getMessageTranslate('details', attr, True))
         if not check_if_translated_field('country', attr):
-            err['country'] = _("This field is required.")
+            err.update(getMessageTranslate('country', attr, True))
         if not check_if_translated_field('state_province', attr):
-            err['state_province'] = _("This field is required.")
+            err.update(getMessageTranslate('state_province', attr, True))
         if not check_if_translated_field('city', attr):
-            err['city'] = _("This field is required.")
+            err.update(getMessageTranslate('city', attr, True))
         if not check_if_translated_field('address_line1', attr):
-            err['address_line1'] = _("This field is required.")
+            err.update(getMessageTranslate('address_line1', attr, True))
         if not check_if_translated_field('timezone', attr):
             err['timezone'] = _("This field is required.")
         if not check_if_translated_field('postal_code', attr):

--- a/workplace/serializers.py
+++ b/workplace/serializers.py
@@ -22,7 +22,8 @@ from django.utils.translation import ugettext_lazy as _
 
 from blitz_api.serializers import UserSerializer
 from blitz_api.services import (remove_translation_fields,
-                                check_if_translated_field,)
+                                check_if_translated_field,
+                                getMessageTranslate,)
 
 from .models import Workplace, Picture, Period, TimeSlot, Reservation
 from .fields import TimezoneField
@@ -84,17 +85,17 @@ class WorkplaceSerializer(serializers.HyperlinkedModelSerializer):
     def validate(self, attr):
         err = {}
         if not check_if_translated_field('name', attr):
-            err['name'] = _("This field is required.")
+            err.update(getMessageTranslate('name', attr, True))
         if not check_if_translated_field('details', attr):
-            err['details'] = _("This field is required.")
+            err.update(getMessageTranslate('details', attr, True))
         if not check_if_translated_field('country', attr):
-            err['country'] = _("This field is required.")
+            err.update(getMessageTranslate('country', attr, True))
         if not check_if_translated_field('state_province', attr):
-            err['state_province'] = _("This field is required.")
+            err.update(getMessageTranslate('state_province', attr, True))
         if not check_if_translated_field('city', attr):
-            err['city'] = _("This field is required.")
+            err.update(getMessageTranslate('city', attr, True))
         if not check_if_translated_field('address_line1', attr):
-            err['address_line1'] = _("This field is required.")
+            err.update(getMessageTranslate('address_line1', attr, True))
         if not check_if_translated_field('timezone', attr):
             err['timezone'] = _("This field is required.")
         if not check_if_translated_field('postal_code', attr):


### PR DESCRIPTION

| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | [Fix]
| Tickets (_issues_) concerned               | [https://fjnr-inc.atlassian.net/jira/software/projects/TV/boards/2?selectedIssue=TV-195]

---

##### What have you changed ?
return internationalized errors

example : 
name : This field is required
name_fr : One of the two fields name must be completed.
name_en : One of the two fields name must be completed.

instead of :
name : This field is required

##### How did you change it ?
add the use of the function getMessageTranslate in worplace and retirement's serializer' validate method.


##### Is there a special consideration?
1-I changed the attribute "both_required" in getMessageTranslate to "only_one_required" since this named seemed more representative of the attribute. Maybe this should be confirmed with Willy.
2-I didn't use getMessageTranslate on every field, only the internationalized one. It may be better to use it with every field? I don't know.
3-I noticed when testing with the frontend that non-internationalized error are displayed first, and only when they are all fixed are internationalized errors displayed. It was like that before my changes, and I didn't look further to enhance this (I think it would be better to have all the errors displayed at once, but not high-priority) 

Verification :
 -  [ ] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [ ] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [ ] My additions are I18N
 -  [X] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 -  [ ] I added or modified the documentation