### PR TITLE
Add chartjs stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## New changes
  
  - add has_shared_rooms to retirements
+ - Add ChartJS mixins for orderlines, to be able to get some stat on sell
 
 
 ## Deprecations 

--- a/blitz_api/chartjs.py
+++ b/blitz_api/chartjs.py
@@ -1,0 +1,201 @@
+import string
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import QuerySet, Sum, Count
+from django.db.models.functions import TruncMonth, TruncDay, \
+    TruncWeek, TruncYear
+from django.http import HttpRequest
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAdminUser
+from rest_framework.response import Response
+from rest_framework import status
+from django.template.defaultfilters import date
+
+
+class ChartJSMixin(object):
+    date_field: string = None
+    quantity_field: string = None
+
+    INTERVAL = 'interval'
+    AGGREGATE = 'aggregate'
+    END = 'end'
+    START = 'start'
+    GROUP_BY_OBJECT = 'group_by_object'  # object_id or content_type
+    group_by_object = False
+
+    QUANTITY = 'quantity'
+    CONTENT_TYPE = 'content_type'
+    OBJECT_ID = 'object_id'
+
+    @action(detail=False, permission_classes=[IsAdminUser])
+    def chartjs(self, request: HttpRequest):
+
+        queryset: QuerySet = self.get_queryset()
+
+        interval_param = request.GET.get(self.INTERVAL)
+        aggregate_param = request.GET.get(self.AGGREGATE)
+        end_param = request.GET.get(self.END)
+        start_param = request.GET.get(self.START)
+        self.group_by_object = request.GET.get(self.GROUP_BY_OBJECT)
+
+        if end_param:
+            queryset = queryset. \
+                filter(**{self.date_field + '__lte': end_param})
+
+        if start_param:
+            queryset = queryset. \
+                filter(**{self.date_field + '__gte': start_param})
+
+        queryset_agregate = queryset \
+            .annotate(interval=self.get_interval(interval_param))
+
+        if self.group_by_object:
+            queryset_agregate = queryset_agregate \
+                .values(self.INTERVAL,
+                        self.CONTENT_TYPE,
+                        self.OBJECT_ID)
+        else:
+            queryset_agregate = queryset_agregate \
+                .values(self.INTERVAL,
+                        self.CONTENT_TYPE)
+
+        queryset_agregate = queryset_agregate \
+            .order_by(self.INTERVAL) \
+            .annotate(quantity=self.get_aggregate(aggregate_param))
+
+        if self.group_by_object:
+            queryset_agregate = queryset_agregate \
+                .values(self.INTERVAL,
+                        self.CONTENT_TYPE,
+                        self.OBJECT_ID,
+                        self.QUANTITY)
+        else:
+            queryset_agregate = queryset_agregate \
+                .values(self.INTERVAL,
+                        self.CONTENT_TYPE,
+                        self.QUANTITY)
+
+        intervals = self.get_intervals(queryset_agregate)
+
+        data_sets = self.get_datasets(queryset_agregate)
+
+        response_data = {
+            'labels': intervals,
+            'datasets':
+                data_sets
+        }
+
+        return Response(
+            status=status.HTTP_200_OK,
+            data=response_data
+        )
+
+    def get_intervals(self, queryset):
+        labels = set([data.get(self.INTERVAL) for data in queryset])
+        labels = list(labels)
+        labels.sort()
+
+        return labels
+
+    def get_datasets(self, queryset_agregate):
+
+        data_set_types = self.get_data_set_types(queryset_agregate)
+
+        data_sets = []
+        for data_set_type in data_set_types:
+            data_set = {
+                'label': self.get_label(data_set_type),
+                'data': self.get_data(
+                    queryset_agregate, data_set_type)
+            }
+            data_sets.append(data_set)
+
+        return data_sets
+
+    def get_data_set_types(self, queryset_agregate):
+
+        if self.group_by_object:
+
+            data_set_types = set([
+                (data.get(self.CONTENT_TYPE), data.get(self.OBJECT_ID))
+                for data in queryset_agregate
+            ])
+        else:
+            data_set_types = set([
+                data.get(self.CONTENT_TYPE)
+                for data in queryset_agregate
+            ])
+
+        return data_set_types
+
+    def get_label(self, data_set_type):
+        if self.group_by_object:
+            content_type, object_id = data_set_type
+            try:
+                object_data = ContentType.objects \
+                    .get(id=content_type) \
+                    .get_object_for_this_type(id=object_id)
+
+                return str(object_data)
+            except ObjectDoesNotExist:
+                content_type_name = ContentType.objects. \
+                    get(id=content_type).name
+                return f'{content_type_name} - {object_id}'
+
+        else:
+            return ContentType.objects.get(id=data_set_type).name
+
+    def get_data(self, queryset_agregate, data_set_type):
+
+        if self.group_by_object:
+            content_type, object_id = data_set_type
+            queryset_filtered = queryset_agregate.filter(
+                **{
+                    self.CONTENT_TYPE: content_type,
+                    self.OBJECT_ID: object_id
+                }
+            )
+
+        else:
+            queryset_filtered = queryset_agregate.filter(
+                **{
+                    self.CONTENT_TYPE: data_set_type,
+                }
+            )
+
+        return [dict(
+            {'x': data.get(self.INTERVAL),
+             'y': data.get(self.QUANTITY)
+             })
+            for data in queryset_filtered]
+
+    def get_interval(self, interval_param):
+
+        trunc_function = TruncMonth
+
+        if interval_param == 'day':
+            trunc_function = TruncDay
+
+        if interval_param == 'week':
+            trunc_function = TruncWeek
+
+        if interval_param == 'month':
+            trunc_function = TruncMonth
+
+        if interval_param == 'year':
+            trunc_function = TruncYear
+
+        return trunc_function(self.date_field)
+
+    def get_aggregate(self, aggregate_param):
+
+        aggregate_function = Sum
+
+        if aggregate_param == 'sum':
+            aggregate_function = Sum
+
+        if aggregate_param == 'count':
+            aggregate_function = Count
+
+        return aggregate_function(self.quantity_field)

--- a/blitz_api/chartjs.py
+++ b/blitz_api/chartjs.py
@@ -14,19 +14,54 @@ from django.template.defaultfilters import date
 
 
 class ChartJSMixin(object):
+    """
+    We can use this mixin in a view to get formatted data for ChartJS
+    It extract from a queryset sum of a quantity field,
+    group by an interval on a date field.
+    The interval can be:
+     - day
+     - week
+     - month
+     - year
+     It can be filter by start and end date.
+     The final format will be like this:
+     {
+        'labels': ['2019-01-01T00:00:00-05:00'],
+        'datasets': [
+            {
+                'label': 'Package',
+                'data': [
+                    {
+                        'x': '2019-01-01T00:00:00-05:00',
+                        'y': 100
+                    }, ...
+                ]
+            }
+        ]
+    }
+
+    labels is the distinct list of all 'x' of all datatesets
+    """
+
+    # attribute to be overwrite in the view
+    # The field to be used to get the date
     date_field: string = None
+    # The field to be used to get the quantity to sum
     quantity_field: string = None
 
+    # Http Parameters key
     INTERVAL = 'interval'
     AGGREGATE = 'aggregate'
     END = 'end'
     START = 'start'
     GROUP_BY_OBJECT = 'group_by_object'  # object_id or content_type
-    group_by_object = False
 
+    # Key data extracted
     QUANTITY = 'quantity'
     CONTENT_TYPE = 'content_type'
     OBJECT_ID = 'object_id'
+
+    group_by_object = False
 
     @action(detail=False, permission_classes=[IsAdminUser])
     def chartjs(self, request: HttpRequest):

--- a/store/tests/test_stats_OrderLine.py
+++ b/store/tests/test_stats_OrderLine.py
@@ -1,0 +1,280 @@
+import json
+
+from rest_framework.test import APIClient, APITestCase
+from blitz_api.factories import UserFactory, AdminFactory
+
+from datetime import timedelta
+
+from django.utils import timezone
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+
+from blitz_api.models import AcademicLevel
+
+from ..models import Membership, Order, OrderLine, Package
+
+
+class OrderLineStatsTests(APITestCase):
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = UserFactory()
+        self.admin = AdminFactory()
+        self.package_type = ContentType.objects.get_for_model(Package)
+        self.academic_level = AcademicLevel.objects.create(
+            name="University"
+        )
+        self.membership_with_academic_level = Membership.objects.create(
+            name="basic_membership",
+            details="1-Year student membership",
+            available=True,
+            price=50,
+            duration=timedelta(days=365),
+        )
+        self.membership_with_academic_level.academic_levels.set([
+            self.academic_level
+        ])
+        self.membership = Membership.objects.create(
+            name="basic_membership",
+            details="1-Year student membership",
+            available=True,
+            price=50,
+            duration=timedelta(days=365),
+        )
+        self.package = Package.objects.create(
+            name="extreme_package",
+            details="100 reservations package",
+            available=True,
+            price=40,
+            reservations=100,
+        )
+        self.package.exclusive_memberships.set([
+            self.membership,
+        ])
+        self.order = Order.objects.create(
+            user=self.user,
+            transaction_date=timezone.now(),
+            authorization_id=1,
+            settlement_id=1,
+        )
+        self.order_admin = Order.objects.create(
+            user=self.admin,
+            transaction_date=timezone.now(),
+            authorization_id=1,
+            settlement_id=1,
+        )
+        self.order_line = OrderLine.objects.create(
+            order=self.order,
+            quantity=1,
+            content_type=self.package_type,
+            object_id=self.package.id,
+            cost=self.package.price,
+        )
+        self.order_line_admin = OrderLine.objects.create(
+            order=self.order_admin,
+            quantity=99,
+            content_type=self.package_type,
+            object_id=self.package.id,
+            cost=99 * self.package.price,
+        )
+
+    def test_chartJS(self):
+        """
+        Ensure we get not found when asking for an order line that doesn't
+        exist.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get(
+            reverse(
+                'orderline-chartjs'
+            ) + '?interval=day&aggregate=sum',
+        )
+
+        content = {
+            'labels': ['2019-08-11T00:00:00-04:00'],
+            'datasets': [
+                {
+                    'label': 'Package',
+                    'data':
+                        [
+                            {
+                                'x': '2019-08-11T00:00:00-04:00',
+                                'y': 100
+                            }
+                        ]
+                }
+            ]
+        }
+
+        self.assertEqual(json.loads(response.content), content)
+
+    def test_chartJS_interval_month(self):
+        """
+        Ensure we get not found when asking for an order line that doesn't
+        exist.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get(
+            reverse(
+                'orderline-chartjs'
+            ) + '?interval=month&aggregate=sum',
+        )
+
+        content = {
+            'labels': ['2019-08-01T00:00:00-04:00'],
+            'datasets': [
+                {
+                    'label': 'Package',
+                    'data': [
+                        {
+                            'x': '2019-08-01T00:00:00-04:00',
+                            'y': 100
+                        }
+                    ]
+                }
+            ]
+        }
+
+        self.assertEqual(json.loads(response.content), content)
+
+    def test_chartJS_interval_month_filter_date(self):
+        """
+        Ensure we get not found when asking for an order line that doesn't
+        exist.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get(
+            reverse(
+                'orderline-chartjs'
+            ) + '?interval=month&aggregate=sum' +
+            'start=2018-01-01T00:00:00.000Z' +
+            'end=2020-01-01T00:00:00.000Z'
+        )
+
+        content = {
+            'labels': ['2019-08-01T00:00:00-04:00'],
+            'datasets': [
+                {
+                    'label': 'Package',
+                    'data': [
+                        {
+                            'x': '2019-08-01T00:00:00-04:00',
+                            'y': 100
+                        }
+                    ]
+                }
+            ]
+        }
+
+        self.assertEqual(json.loads(response.content), content)
+
+    def test_chartJS_interval_month_content_type_filter(self):
+        """
+        Ensure we get not found when asking for an order line that doesn't
+        exist.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get(
+            reverse(
+                'orderline-chartjs'
+            ) + '?interval=month&aggregate=sum&content_type=' +
+            str(self.package_type.id),
+        )
+
+        content = {
+            'labels': ['2019-08-01T00:00:00-04:00'],
+            'datasets': [
+                {
+                    'label': 'Package',
+                    'data': [
+                        {
+                            'x': '2019-08-01T00:00:00-04:00',
+                            'y': 100
+                        }
+                    ]
+                }
+            ]
+        }
+
+        self.assertEqual(json.loads(response.content), content)
+
+    def test_chartJS_interval_month_with_detail(self):
+        """
+        Ensure we get not found when asking for an order line that doesn't
+        exist.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get(
+            reverse(
+                'orderline-chartjs'
+            ) + '?interval=month&aggregate=sum&group_by_object=True',
+        )
+
+        content = {'labels': ['2019-08-01T00:00:00-04:00'], 'datasets': [
+            {'label': 'extreme_package',
+             'data': [{'x': '2019-08-01T00:00:00-04:00', 'y': 100}]}]}
+
+        self.assertEqual(json.loads(response.content), content)
+
+    def test_chartJS_interval_week(self):
+        """
+        Ensure we get not found when asking for an order line that doesn't
+        exist.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get(
+            reverse(
+                'orderline-chartjs'
+            ) + '?interval=week&aggregate=sum',
+        )
+
+        content = {'labels': ['2019-08-05T00:00:00-04:00'], 'datasets': [
+            {'label': 'Package',
+             'data': [{'x': '2019-08-05T00:00:00-04:00', 'y': 100}]}]}
+
+        self.assertEqual(json.loads(response.content), content)
+
+    def test_chartJS_interval_year(self):
+        """
+        Ensure we get not found when asking for an order line that doesn't
+        exist.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get(
+            reverse(
+                'orderline-chartjs'
+            ) + '?interval=year&aggregate=sum',
+        )
+
+        content = {'labels': ['2019-01-01T00:00:00-05:00'], 'datasets': [
+            {'label': 'Package',
+             'data': [{'x': '2019-01-01T00:00:00-05:00', 'y': 100}]}]}
+
+        self.assertEqual(json.loads(response.content), content)
+
+    def test_chartJS_interval_month_count(self):
+        """
+        Ensure we get not found when asking for an order line that doesn't
+        exist.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get(
+            reverse(
+                'orderline-chartjs'
+            ) + '?interval=month&aggregate=count',
+        )
+
+        content = {'labels': ['2019-08-01T00:00:00-04:00'], 'datasets': [
+            {'label': 'Package',
+             'data': [{'x': '2019-08-01T00:00:00-04:00', 'y': 2}]}]}
+
+        self.assertEqual(json.loads(response.content), content)

--- a/store/tests/tests_viewset_OrderLine.py
+++ b/store/tests/tests_viewset_OrderLine.py
@@ -714,8 +714,8 @@ class OrderLineTests(APITestCase):
 
     def test_product_list(self):
         """
-        Ensure we get not found when asking for an order line that doesn't
-        exist.
+        Get list of product, get content_type name group by content_type in
+        all order line
         """
         self.client.force_authenticate(user=self.admin)
 

--- a/store/tests/tests_viewset_OrderLine.py
+++ b/store/tests/tests_viewset_OrderLine.py
@@ -711,3 +711,26 @@ class OrderLineTests(APITestCase):
         self.assertEqual(json.loads(response.content), content)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_product_list(self):
+        """
+        Ensure we get not found when asking for an order line that doesn't
+        exist.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get(
+            reverse(
+                'orderline-list'
+            ) + '/product_list',
+        )
+
+        content = [
+            {
+                'name': 'Package',
+                'id': 35,
+                'detail': True
+            }
+        ]
+
+        self.assertEqual(json.loads(response.content), content)

--- a/store/views.py
+++ b/store/views.py
@@ -298,7 +298,11 @@ class OrderLineViewSet(ExportMixin, ChartJSMixin, viewsets.ModelViewSet):
 
     @action(detail=False, permission_classes=[IsAdminUser])
     def product_list(self, request: HttpRequest):
-
+        """
+        Get content_type name, id and if he can display details group by
+        content_type in all order lines
+        Use to filter by content_type in ChartJS call
+        """
         product_list = list(self.get_queryset()
                             .distinct('content_type')
                             .values('content_type'))

--- a/store/views.py
+++ b/store/views.py
@@ -3,7 +3,8 @@ import pytz
 from datetime import datetime
 
 from django.conf import settings
-from django.http import Http404, HttpResponse
+from django.contrib.contenttypes.models import ContentType
+from django.http import Http404, HttpResponse, HttpRequest
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
@@ -13,6 +14,7 @@ from rest_framework.decorators import action, permission_classes
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.response import Response
 
+from blitz_api.chartjs import ChartJSMixin
 from blitz_api.mixins import ExportMixin
 
 from .exceptions import PaymentAPIError
@@ -26,7 +28,6 @@ from .services import (delete_external_card, validate_coupon_for_order,
                        notify_for_coupon, )
 
 from . import serializers, permissions
-
 
 LOCAL_TIMEZONE = pytz.timezone(settings.TIME_ZONE)
 
@@ -255,7 +256,7 @@ class OrderViewSet(ExportMixin, viewsets.ModelViewSet):
         return Order.objects.filter(user=self.request.user.id)
 
 
-class OrderLineViewSet(ExportMixin, viewsets.ModelViewSet):
+class OrderLineViewSet(ExportMixin, ChartJSMixin, viewsets.ModelViewSet):
     """
     retrieve:
     Return the given order line.
@@ -269,8 +270,14 @@ class OrderLineViewSet(ExportMixin, viewsets.ModelViewSet):
     serializer_class = serializers.OrderLineSerializer
     queryset = OrderLine.objects.all()
     permission_classes = (IsAuthenticated,)
+    filter_fields = {
+        'order__transaction_date': ['gte', 'lte']
+    }
 
     export_resource = OrderLineResource()
+
+    date_field = 'order__transaction_date'
+    quantity_field = 'quantity'
 
     def get_queryset(self):
         """
@@ -278,8 +285,40 @@ class OrderLineViewSet(ExportMixin, viewsets.ModelViewSet):
         the currently authenticated user is an admin (is_staff).
         """
         if self.request.user.is_staff:
+            product_param = self.request.GET.getlist('content_type')
+            if product_param:
+                product_param = [int(product_id)
+                                 for product_id in product_param]
+
+                return OrderLine.objects.all(). \
+                    filter(content_type__id__in=product_param)
+
             return OrderLine.objects.all()
         return OrderLine.objects.filter(order__user=self.request.user)
+
+    @action(detail=False, permission_classes=[IsAdminUser])
+    def product_list(self, request: HttpRequest):
+
+        product_list = list(self.get_queryset()
+                            .distinct('content_type')
+                            .values('content_type'))
+
+        product_object_list = []
+
+        for product in product_list:
+            product_object = ContentType.objects.get(
+                id=product.get('content_type'))
+            product_dict = {
+                'name': product_object.name,
+                'id': product_object.id,
+                'detail': product_object.model != 'timeslot'
+            }
+            product_object_list.append(product_dict)
+
+        return Response(
+            status=status.HTTP_200_OK,
+            data=product_object_list
+        )
 
 
 class CustomPaymentViewSet(ExportMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Features
| Tickets (_issues_) concerned               | TV-19

---

##### What have you changed ?
Add a mixin to get data for chartJS

##### How did you change it ?
    We can use this mixin in a view to get formatted data for ChartJS
    It extract from a queryset sum of a quantity field,
    group by an interval on a date field.
    The interval can be:
     - day
     - week
     - month
     - year
     It can be filter by start and end date.
     The final format will be like this:
     {
        'labels': ['2019-01-01T00:00:00-05:00'],
        'datasets': [
            {
                'label': 'Package',
                'data': [
                    {
                        'x': '2019-01-01T00:00:00-05:00',
                        'y': 100
                    }, ...
                ]
            }
        ]
    }

    labels is the distinct list of all 'x' of all datatesets


Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [ ] My additions are I18N
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 -  [x] I added or modified the documentation