### PR TITLE
add missing id on retreatInvitation serializer

### DIFF
--- a/retirement/serializers.py
+++ b/retirement/serializers.py
@@ -960,6 +960,7 @@ class WaitQueueNotificationSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class RetreatInvitationSerializer(serializers.HyperlinkedModelSerializer):
+    id = serializers.ReadOnlyField()
     url_token = serializers.ReadOnlyField()
     front_url = serializers.ReadOnlyField()
     nb_places_used = serializers.ReadOnlyField()


### PR DESCRIPTION
ID is missing in RetreatInvitation serialization but this field is needed to create the metadata we need to add in the POST `/order`

![Screenshot from 2019-09-07 17-27-16](https://user-images.githubusercontent.com/12053720/64480467-0cb50400-d196-11e9-989d-d808cbf35f75.png)
