### PR TITLE
add hidden filter on retreat listing

### DIFF
--- a/retirement/views.py
+++ b/retirement/views.py
@@ -59,6 +59,7 @@ class RetreatViewSet(ExportMixin, viewsets.ModelViewSet):
         'start_time': ['exact', 'gte', 'lte'],
         'end_time': ['exact', 'gte', 'lte'],
         'is_active': ['exact'],
+        'hidden': ['exact'],
     }
     ordering = ('name', 'start_time', 'end_time')
 


### PR DESCRIPTION
Admin can see hidden retreat, but they can't filter retreat to hide them when they want to see data as a normal user.