### PR TITLE
add policy url in invoice email

### DIFF
--- a/blitz_api/settings.py
+++ b/blitz_api/settings.py
@@ -307,30 +307,51 @@ SUPPORT_EMAIL = config('SUPPORT_EMAIL', default='admin@fjnr.ca')
 # User specific settings
 
 LOCAL_SETTINGS = {
-    'ORGANIZATION': config('ORGANIZATION', default='Blitz'),
-    'EMAIL_SERVICE': config('EMAIL_SERVICE', default=False, cast=bool),
-    'AUTO_ACTIVATE_USER': config('AUTO_ACTIVATE_USER', default=False,
-                                 cast=bool),
+    'ORGANIZATION': config(
+        'ORGANIZATION',
+        default='Blitz',
+    ),
+    'EMAIL_SERVICE': config(
+        'EMAIL_SERVICE',
+        default=False,
+        cast=bool,
+    ),
+    'AUTO_ACTIVATE_USER': config(
+        'AUTO_ACTIVATE_USER',
+        default=False,
+        cast=bool,
+    ),
     'FRONTEND_INTEGRATION': {
-        'ACTIVATION_URL': config('ACTIVATION_URL',
-                                 default='https://example.com/activate/{{token}}'),
+        'POLICY_URL': config(
+            'ACTIVATION_URL',
+            default='http://thesez-vous.org/policy',
+        ),
+        'ACTIVATION_URL': config(
+            'ACTIVATION_URL',
+            default='https://example.com/activate/{{token}}',
+        ),
         'EMAIL_CHANGE_CONFIRMATION': config(
             'EMAIL_CHANGE_CONFIRMATION',
             default='https://example.com/validate/email/{{token}}'
         ),
-        'FORGOT_PASSWORD_URL': config('FORGOT_PASSWORD_URL',
-                                      default='https://example.com/reset-password/{{token}}'),
-        'RETREAT_INVITATION_URL':
-            config('RETREAT_INVITATION_URL',
-                   default='https://example.com/retreat_invitation/{{token}}'),
-        'RETREAT_UNSUBSCRIBE_URL':
-            config('RETREAT_UNSUBSCRIBE_URL',
-                   default='https://example.com/wait_queue/'
-                           '{{wait_queue_id}}/unsubscribe'),
+        'FORGOT_PASSWORD_URL': config(
+            'FORGOT_PASSWORD_URL',
+            default='https://example.com/reset-password/{{token}}',
+        ),
+        'RETREAT_INVITATION_URL': config(
+            'RETREAT_INVITATION_URL',
+            default='https://example.com/retreat_invitation/{{token}}',
+        ),
+        'RETREAT_UNSUBSCRIBE_URL': config(
+            'RETREAT_UNSUBSCRIBE_URL',
+            default='https://example.com/wait_queue/{{wait_queue_id}}/unsubscribe',
+        ),
     },
     'SELLING_TAX': 0.14975,
     'RETREAT_NOTIFICATION_LIFETIME_DAYS': config(
-        'RETREAT_NOTIFICATION_LIFETIME_DAYS', default=30),
+        'RETREAT_NOTIFICATION_LIFETIME_DAYS',
+        default=30,
+    ),
 }
 
 # Payment settings

--- a/retirement/serializers.py
+++ b/retirement/serializers.py
@@ -802,16 +802,7 @@ class ReservationSerializer(serializers.HyperlinkedModelSerializer):
                 ),
             }
 
-            plain_msg = render_to_string("invoice.txt", merge_data)
-            msg_html = render_to_string("invoice.html", merge_data)
-
-            send_mail(
-                "Confirmation d'achat",
-                plain_msg,
-                settings.DEFAULT_FROM_EMAIL,
-                [order.user.email],
-                html_message=msg_html,
-            )
+            Order.send_invoice([order.user.email], merge_data)
 
         # Send refund confirmation email
         if need_refund:

--- a/store/models.py
+++ b/store/models.py
@@ -11,7 +11,9 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.fields import (
     GenericForeignKey, GenericRelation
 )
+from django.core.mail import send_mail
 from django.contrib.contenttypes.models import ContentType
+from django.template.loader import render_to_string
 
 from safedelete.models import SafeDeleteModel
 
@@ -97,6 +99,23 @@ class Order(models.Model):
 
     def __str__(self):
         return str(self.authorization_id)
+
+    @staticmethod
+    def send_invoice(to, merge_data):
+        if 'POLICY_URL' not in merge_data.keys():
+            merge_data['POLICY_URL'] = settings.\
+                LOCAL_SETTINGS['FRONTEND_INTEGRATION']['POLICY_URL']
+
+        plain_msg = render_to_string("invoice.txt", merge_data)
+        msg_html = render_to_string("invoice.html", merge_data)
+
+        send_mail(
+            "Confirmation d'achat",
+            plain_msg,
+            settings.DEFAULT_FROM_EMAIL,
+            to,
+            html_message=msg_html,
+        )
 
     def applying_coupon(self, coupon, user):
         from store.services import validate_coupon_for_order

--- a/store/serializers.py
+++ b/store/serializers.py
@@ -327,16 +327,7 @@ class CustomPaymentSerializer(serializers.HyperlinkedModelSerializer):
             'COST': custom_payment.price,
         }
 
-        plain_msg = render_to_string("invoice.txt", merge_data)
-        msg_html = render_to_string("invoice.html", merge_data)
-
-        send_mail(
-            "Confirmation d'achat",
-            plain_msg,
-            settings.DEFAULT_FROM_EMAIL,
-            [custom_payment.user.email],
-            html_message=msg_html,
-        )
+        Order.send_invoice([custom_payment.user.email], merge_data)
 
         return custom_payment
 
@@ -900,16 +891,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
                 'COST': round(amount / 100, 2),
             }
 
-            plain_msg = render_to_string("invoice.txt", merge_data)
-            msg_html = render_to_string("invoice.html", merge_data)
-
-            send_mail(
-                "Confirmation d'achat",
-                plain_msg,
-                settings.DEFAULT_FROM_EMAIL,
-                [order.user.email],
-                html_message=msg_html,
-            )
+            Order.send_invoice([order.user.email], merge_data)
 
         # Send retreat informations emails
         for retreat_reservation in retreat_reservations:

--- a/store/templates/invoice.html
+++ b/store/templates/invoice.html
@@ -738,6 +738,7 @@
               <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
                 <p style="margin: 0 0 10px 0; text-align:center;">
                   Thèsez-vous n'autorise pas d'échanges ou de remboursements en dehors des retraites de rédaction.
+                  <a href="{{POLICY_URL}}">Voir les politiques d'annulation</a>
                 </p>
                 <p style="margin: 10px 0; text-align:center; font-size: 0.8em;">
                   TPS : 706446325 RT0001<br>

--- a/store/templates/invoice.txt
+++ b/store/templates/invoice.txt
@@ -54,7 +54,9 @@ Total
 ** L'ÉQUIPE THÈSEZ-VOUS
 ------------------------------------------------------------
 
-Thèsez-vous n'autorise pas d'échanges ou de remboursements.
+Thèsez-vous n'autorise pas d'échanges ou de remboursements en dehors des retraites de rédaction.
+Voir les politiques d'annulation: {{POLICY_URL}}
+
 Thèsez-vous (Blitz Paradisio), 7640 Lajeunesse, Montréal, Quebec, H2R2J2
 info@thesez-vous.com, www.thesez-vous.com
 


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Enhancement
| Tickets (_issues_) concerned               | None

---

##### What have you changed ?
Add an url in the invoice email to redirect to policy of the organization

##### How did you change it ?
Added a settings
Added the link in HTML and TXT emails

##### Is there a special consideration?
No, default URL is the official one so its plug and play

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [x] My additions are I18N
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 -  [x] I added or modified the documentation