### PR TITLE
Allow admin to create an order for a other user

### DIFF
--- a/store/tests/tests_viewset_Order.py
+++ b/store/tests/tests_viewset_Order.py
@@ -586,6 +586,183 @@ class OrderTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @responses.activate
+    def test_create_reservation_only_from_admin(self):
+
+        FIXED_TIME = datetime(2018, 1, 1, tzinfo=LOCAL_TIMEZONE)
+
+        self.client.force_authenticate(user=self.admin)
+
+        responses.add(
+            responses.POST,
+            "http://example.com/cardpayments/v1/accounts/0123456789/auths/",
+            json=SAMPLE_PAYMENT_RESPONSE,
+            status=200
+        )
+
+        data = {
+            'order_lines': [{
+                'content_type': 'timeslot',
+                'object_id': self.time_slot.id,
+                'quantity': 1,
+            }],
+            'target_user': 'http://testserver/users/' + str(self.user.id),
+            'bypass_payment': False,
+        }
+
+        with mock.patch(
+                'store.serializers.timezone.now', return_value=FIXED_TIME):
+            response = self.client.post(
+                reverse('order-list'),
+                data,
+                format='json',
+            )
+
+        response_data = json.loads(response.content)
+        del response_data['url']
+        del response_data['id']
+        del response_data['transaction_date']
+        del response_data['order_lines'][0]['order']
+        del response_data['order_lines'][0]['object_id']
+        del response_data['order_lines'][0]['url']
+        del response_data['order_lines'][0]['id']
+
+        content = {
+            'order_lines': [{
+                'content_type': 'timeslot',
+                'quantity': 1,
+                'coupon': None,
+                'coupon_real_value': 0.0,
+                'cost': 0.0,
+                'metadata': None,
+                'options': []
+            }],
+            'user': 'http://testserver/users/' + str(self.user.id),
+            'authorization_id': '0',
+            'settlement_id': '0',
+            'reference_number': '0',
+        }
+
+        self.assertEqual(response_data, content)
+
+        user = self.user
+        user.refresh_from_db()
+
+        self.assertEqual(user.tickets, 0)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    @responses.activate
+    def test_create_reservation_only_from_admin_without_payment(self):
+
+        FIXED_TIME = datetime(2018, 1, 1, tzinfo=LOCAL_TIMEZONE)
+
+        self.client.force_authenticate(user=self.admin)
+
+        responses.add(
+            responses.POST,
+            "http://example.com/cardpayments/v1/accounts/0123456789/auths/",
+            json=SAMPLE_PAYMENT_RESPONSE,
+            status=200
+        )
+
+        data = {
+            'order_lines': [{
+                'content_type': 'timeslot',
+                'object_id': self.time_slot.id,
+                'quantity': 1,
+            }],
+            'target_user': 'http://testserver/users/' + str(self.user.id),
+            'bypass_payment': True,
+        }
+
+        with mock.patch(
+                'store.serializers.timezone.now', return_value=FIXED_TIME):
+            response = self.client.post(
+                reverse('order-list'),
+                data,
+                format='json',
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED,
+                         response.content)
+
+        response_data = json.loads(response.content)
+        del response_data['url']
+        del response_data['id']
+        del response_data['transaction_date']
+        del response_data['order_lines'][0]['order']
+        del response_data['order_lines'][0]['object_id']
+        del response_data['order_lines'][0]['url']
+        del response_data['order_lines'][0]['id']
+
+        content = {
+            'order_lines': [{
+                'content_type': 'timeslot',
+                'quantity': 1,
+                'coupon': None,
+                'coupon_real_value': 0.0,
+                'cost': 0.0,
+                'metadata': None,
+                'options': []
+            }],
+            'user': 'http://testserver/users/' + str(self.user.id),
+            'authorization_id': '0',
+            'settlement_id': '0',
+            'reference_number': '0',
+        }
+
+        self.assertEqual(response_data, content)
+
+        user = self.user
+        user.refresh_from_db()
+
+        self.assertEqual(user.tickets, 1)
+
+    @responses.activate
+    def test_create_reservation_only_from_not_admin(self):
+
+        FIXED_TIME = datetime(2018, 1, 1, tzinfo=LOCAL_TIMEZONE)
+
+        self.client.force_authenticate(user=self.user)
+
+        responses.add(
+            responses.POST,
+            "http://example.com/cardpayments/v1/accounts/0123456789/auths/",
+            json=SAMPLE_PAYMENT_RESPONSE,
+            status=200
+        )
+
+        data = {
+            'order_lines': [{
+                'content_type': 'timeslot',
+                'object_id': self.time_slot.id,
+                'quantity': 1,
+            }],
+            'target_user': 'http://testserver/users/' + str(self.user.id),
+            'bypass_payment': False,
+        }
+
+        with mock.patch(
+                'store.serializers.timezone.now', return_value=FIXED_TIME):
+            response = self.client.post(
+                reverse('order-list'),
+                data,
+                format='json',
+            )
+
+        response_data = json.loads(response.content)
+
+        content = {
+            'non_field_errors':
+                [
+                    'You don\'t have the permission to create '
+                    'an order for another user.'
+                ]
+        }
+
+        self.assertEqual(response_data, content)
+
+    @responses.activate
     def test_create_reservation_twice(self):
         """
         Ensure we can't create an order for the same reservation twice.


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Features
| Tickets (_issues_) concerned               | []

---

##### What have you changed ?
Allow admin to create an order for a other user

##### How did you change it ?
Add target_user in sérialiser, and validate if the request user is staff

##### Is there a special consideration?
...

Verification :
 -  [ ] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [ ] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [ ] My additions are I18N
 -  [ ] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 -  [ ] I added or modified the documentation