### PR TITLE
Remove "," when generating retreat_notification_url

### DIFF
--- a/retirement/serializers.py
+++ b/retirement/serializers.py
@@ -756,7 +756,7 @@ class ReservationSerializer(serializers.HyperlinkedModelSerializer):
                     'retreat:retreat-notify',
                     args=[current_retreat.id]
                 )
-            ),
+            )
             current_retreat.notify_scheduler_waite_queue(
                 retrat_notification_url)
 

--- a/retirement/views.py
+++ b/retirement/views.py
@@ -422,7 +422,7 @@ class ReservationViewSet(ExportMixin, viewsets.ModelViewSet):
                         'retreat:retreat-notify',
                         args=[retreat.id]
                     )
-                ),
+                )
                 retreat.notify_scheduler_waite_queue(
                     retreat_notification_url)
 


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Fix
| Tickets (_issues_) concerned               | https://fjnr.freshdesk.com/a/tickets/136

---

##### What have you changed ?
Remove "," when generating retreat_notification_url
Add test to cover this

##### How did you change it ?
...

##### Is there a special consideration?
...

Verification :
 -  [ ] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [ ] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [ ] My additions are I18N
 -  [ ] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 -  [ ] I added or modified the documentation