### PR TITLE
allow admin to cancel reservation and force refund

### DIFF
--- a/retirement/models.py
+++ b/retirement/models.py
@@ -422,6 +422,7 @@ class Reservation(SafeDeleteModel):
         ('U', _("User canceled")),
         ('RD', _("Retreat deleted")),
         ('RM', _("Retreat modified")),
+        ('A', _("Admin canceled")),
     )
 
     CANCELATION_ACTION = (


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Enhancement
| Tickets (_issues_) concerned               | [TV-297](https://fjnr-inc.atlassian.net/browse/TV-297)

---

##### What have you changed ?

 - Allow admin to cancel reservation of a user
 - Allow admin to force refund if possible

##### How did you change it ?

- Refactor `ReservationViewSet.destroy()` in order to define if we need to refund or not the reservation
 - Add a new `cancellation_reason` to keep trace when admin cancelled a reservation for a user


##### Is there a special consideration?

I can't test the refund new field with unit test since we lack some mock on this part. I tested it on local and a QA will be needed on the QA server to validate properly the functionnality.

...

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [x] My additions are I18N
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 -  [x] I added or modified the documentation