### PR TITLE
Update django-anymail, cast template id to int

### DIFF
--- a/blitz_api/mailchimp.py
+++ b/blitz_api/mailchimp.py
@@ -49,5 +49,3 @@ def is_email_on_list(
     except MailChimpError:
         return False
     return True if member else False
-
-

--- a/blitz_api/settings.py
+++ b/blitz_api/settings.py
@@ -283,12 +283,14 @@ ANYMAIL = {
     'REQUESTS_TIMEOUT': config('REQUESTS_TIMEOUT', default=(30, 30),
                                cast=tuple),
     'TEMPLATES': {
-        'CONFIRM_SIGN_UP': config('CONFIRM_SIGN_UP', default='example_id'),
-        'FORGOT_PASSWORD': config('FORGOT_PASSWORD', default='example_id'),
+        'CONFIRM_SIGN_UP':
+            config('CONFIRM_SIGN_UP', default='0', cast=int),
+        'FORGOT_PASSWORD':
+            config('FORGOT_PASSWORD', default='0', cast=int),
         'RESERVATION_CANCELLED': config('RESERVATION_CANCELLED',
-                                        default='example_id'),
+                                        default='0', cast=int),
         'CONFIRM_CHANGE_EMAIL': config('CONFIRM_CHANGE_EMAIL',
-                                       default='example_id'),
+                                       default='0', cast=int),
     },
 }
 EMAIL_BACKEND = config('EMAIL_BACKEND',

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ coreapi==2.3.3
 factory-boy==2.12.0
 Pygments==2.5.2
 Markdown==3.2.1
-django-anymail==6.1.0
+django-anymail==7.1.0
 Pillow==7.0.0
 django-simple-history==2.8.0
 djangorestframework-filters==0.11.1

--- a/workplace/admin.py
+++ b/workplace/admin.py
@@ -126,6 +126,7 @@ class ReservationAdmin(SimpleHistoryAdmin, SafeDeleteAdmin,
     class Media:
         pass
 
+
 admin.site.register(Workplace, WorkplaceAdmin)
 admin.site.register(Picture, PictureAdmin)
 admin.site.register(Period, PeriodAdmin)


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Enhancement
| Tickets (_issues_) concerned               | []

---

##### What have you changed ?
Change requirement, add cast to template id in setting, not working without it
Sendinblue template need to be update in same time than update the serveur
It won't work with :
- old-template and new anymail
- new-template and old anymail

##### How did you change it ?
...

##### Is there a special consideration?
...

Verification :
 -  [ ] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [ ] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [ ] My additions are I18N
 -  [ ] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 -  [ ] I added or modified the documentation