### PR TITLE
Fix overlapping date of retreat

### DIFF
--- a/retirement/serializers.py
+++ b/retirement/serializers.py
@@ -385,7 +385,7 @@ class ReservationSerializer(serializers.HyperlinkedModelSerializer):
         active_reservations = active_reservations.all()
 
         for reservation in active_reservations:
-            for date in reservation.retreat.retreat_dates:
+            for date in reservation.retreat.retreat_dates.all():
                 latest_start = max(
                     date.start_time,
                     start,
@@ -592,7 +592,7 @@ class ReservationSerializer(serializers.HyperlinkedModelSerializer):
                 ).exclude(pk=instance.pk)
 
                 for reservation in active_reservations:
-                    for date in reservation.retreat.retreat_dates:
+                    for date in reservation.retreat.retreat_dates.all():
                         latest_start = max(
                             date.start_time,
                             start,

--- a/retirement/serializers.py
+++ b/retirement/serializers.py
@@ -385,15 +385,22 @@ class ReservationSerializer(serializers.HyperlinkedModelSerializer):
         active_reservations = active_reservations.all()
 
         for reservation in active_reservations:
-            latest_start = max(reservation.retreat.start_time, start)
-            shortest_end = min(reservation.retreat.end_time, end)
-            if latest_start < shortest_end:
-                raise serializers.ValidationError({
-                    'non_field_errors': [_(
-                        "This reservation overlaps with another active "
-                        "reservations for this user."
-                    )]
-                })
+            for date in reservation.retreat.retreat_dates:
+                latest_start = max(
+                    date.start_time,
+                    start,
+                )
+                shortest_end = min(
+                    date.end_time,
+                    end,
+                )
+                if latest_start < shortest_end:
+                    raise serializers.ValidationError({
+                        'non_field_errors': [_(
+                            "This reservation overlaps with another active "
+                            "reservations for this user."
+                        )]
+                    })
         return attrs
 
     def create(self, validated_data):
@@ -585,15 +592,22 @@ class ReservationSerializer(serializers.HyperlinkedModelSerializer):
                 ).exclude(pk=instance.pk)
 
                 for reservation in active_reservations:
-                    latest_start = max(reservation.retreat.start_time, start)
-                    shortest_end = min(reservation.retreat.end_time, end)
-                    if latest_start < shortest_end:
-                        raise serializers.ValidationError({
-                            'non_field_errors': [_(
-                                "This reservation overlaps with another "
-                                "active reservations for this user."
-                            )]
-                        })
+                    for date in reservation.retreat.retreat_dates:
+                        latest_start = max(
+                            date.start_time,
+                            start,
+                        )
+                        shortest_end = min(
+                            date.end_time,
+                            end,
+                        )
+                        if latest_start < shortest_end:
+                            raise serializers.ValidationError({
+                                'non_field_errors': [_(
+                                    "This reservation overlaps with another "
+                                    "active reservations for this user."
+                                )]
+                            })
                 if need_transaction:
                     order = Order.objects.create(
                         user=user,


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Fix
| Tickets (_issues_) concerned               | [Freshdesk 856](https://fjnr.freshdesk.com/a/tickets/856)

---

##### What have you changed ?
Change method to calculate overlapping on retreat's date

##### How did you change it ?
Base calculation on `RetreatDate` and no more on `Retreat` properties

##### Is there a special consideration?
No

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [x] My additions are I18N
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 -  [x] I added or modified the documentation