### PR TITLE
disable edit membership_end

### DIFF
--- a/blitz_api/serializers.py
+++ b/blitz_api/serializers.py
@@ -372,6 +372,7 @@ class UserUpdateSerializer(serializers.HyperlinkedModelSerializer):
             'groups',
             'user_permissions',
             'reservations',
+            'membership_end'
         )
 
 


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Fix
| Tickets (_issues_) concerned               | [TV-332](https://fjnr-inc.atlassian.net/browse/TV-332)

---

##### What have you changed ?
Disable edit membership_end

##### How did you change it ?
Add membership_end to read_only fields

##### Is there a special consideration?
...

Verification :
 -  [ ] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [ ] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [ ] My additions are I18N
 -  [ ] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 -  [ ] I added or modified the documentation