### PR TITLE
Add inline limitation on cron task

### DIFF
--- a/cron_manager/admin.py
+++ b/cron_manager/admin.py
@@ -19,6 +19,11 @@ class ExecutionInline(admin.StackedInline):
     readonly_fields = ('created_at',)
     max_num = 10
 
+    def get_queryset(self, request):
+        LIMIT_SEARCH = 25
+        queryset = super(ExecutionInline, self).get_queryset(request)
+        return queryset.order_by('-id')[:LIMIT_SEARCH]
+
 
 class TaskAdmin(admin.ModelAdmin):
     inlines = (ExecutionInline,)


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Fix
| Tickets (_issues_) concerned               | None

---

##### What have you changed ?
Limit the number of Execution display inline the Task admin panel page to avoid timeout

##### How did you change it ?
Add a queryset into the inline admin definition

##### Is there a special consideration?
Only the 25 most recent execution will be displayed

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [x] My additions are I18N
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 -  [x] I added or modified the documentation