### PR TITLE
fix(reservation-retreat): overlapping of reservation data

### DIFF
--- a/retirement/views.py
+++ b/retirement/views.py
@@ -178,7 +178,7 @@ class RetreatViewSet(ExportMixin, viewsets.ModelViewSet):
         """
         try:
             retreat = Retreat.objects.get(pk=pk)
-        except:
+        except Exception:
             response_data = {
                 'detail': "Retreat not found"
             }


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Fix
| Tickets (_issues_) concerned               | [Ticket 2608](https://redmine.fjnr.ca/issues/2608)

---

##### What have you changed ?
Refactor the calculation of the overlapping

##### How did you change it ?
Calculate the overlapping for ALL the dates of the retreats and not the complete interval

##### Is there a special consideration?
No, but need to be tested on QA as always

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [x] My additions are I18N
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 -  [x] I added or modified the documentation