### PR TITLE
fix queryset for automatic email cron task

### DIFF
--- a/retirement/views.py
+++ b/retirement/views.py
@@ -176,7 +176,14 @@ class RetreatViewSet(ExportMixin, viewsets.ModelViewSet):
         notify a users who will attend the retreat with an existing
         automated email pre-configured (AutomaticEmail).
         """
-        retreat = self.get_object()
+        try:
+            retreat = Retreat.objects.get(pk=pk)
+        except:
+            response_data = {
+                'detail': "Retreat not found"
+            }
+            return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
+
         try:
             email = AutomaticEmail.objects.get(
                 id=int(request.GET.get('email'))


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Fix
| Tickets (_issues_) concerned               | [Ticket 2618](https://redmine.fjnr.ca/issues/2618)

---

##### What have you changed ?
Allow hidden retreat on automatic email

##### How did you change it ?
Fix the queryset on the specific action viewset

##### Is there a special consideration?
Since the bug stacked a lot of cron task as 404 with auto-retry we **should make sure** to remove the old `Tasks` that are too old to be done today. Only recent `Task` should be keeped and auto-retry with the fix.

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [x] My additions are I18N
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 -  [x] I added or modified the documentation