### PR TITLE
feat(retreat): add bulk creation for retreat

### DIFF
--- a/retirement/serializers.py
+++ b/retirement/serializers.py
@@ -291,6 +291,38 @@ class RetreatSerializer(BaseProductSerializer):
         }
 
 
+class BatchRetreatSerializer(RetreatSerializer):
+    bulk_start_time = serializers.DateTimeField()
+    bulk_end_time = serializers.DateTimeField()
+    weekdays = serializers.ListField(
+        child=serializers.IntegerField(
+            max_value=6,
+            min_value=0
+        )
+    )
+
+    def validate_weekdays(self, weekdays):
+        """
+        Check that no weekday is duplicated.
+        """
+        if len(weekdays) != len(set(weekdays)):
+            raise serializers.ValidationError(_(
+                "Duplicated weekdays are not authorized."
+            ))
+        return weekdays
+
+    def validate(self, attrs):
+        if attrs.get('bulk_start_time') and \
+                attrs.get('bulk_end_time') and \
+                attrs.get('bulk_start_time') >= attrs.get('bulk_end_time'):
+            raise serializers.ValidationError({
+                'bulk_end_time': [_("End time must be later than start time.")],
+                'bulk_start_time': [_("Start time must be earlier than end time.")],
+            })
+
+        return attrs
+
+
 class PictureSerializer(serializers.HyperlinkedModelSerializer):
     id = serializers.ReadOnlyField()
 

--- a/retirement/tests/tests_viewset_Retreat.py
+++ b/retirement/tests/tests_viewset_Retreat.py
@@ -363,6 +363,159 @@ class RetreatTests(CustomAPITestCase):
         }
     )
     @responses.activate
+    def test_create_batch_retreat_with_missing_field(self):
+        """
+        Ensure we can't create a batch retreat without bulk date.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        responses.add(
+            responses.POST,
+            "http://example.com/authentication",
+            json={"token": "1234567890"},
+            status=200
+        )
+
+        responses.add(
+            responses.POST,
+            "http://example.com/tasks",
+            status=200
+        )
+
+        data = {
+            'name': "random_retreat",
+            'seats': 40,
+            'details': "short_description",
+            'timezone': "America/Montreal",
+            'price': '100.00',
+            'min_day_refund': 7,
+            'min_day_exchange': 7,
+            'refund_rate': 50,
+            'hidden': False,
+            'description': None,
+            'sub_title': None,
+            'postal_code': None,
+            'place_name': None,
+            'type': reverse(
+                'retreat:retreattype-detail',
+                args=[self.retreatType.id]
+            ),
+        }
+
+        response = self.client.post(
+            reverse('retreat:retreat-batch-create'),
+            data,
+            format='json',
+        )
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_400_BAD_REQUEST,
+            response.content
+        )
+
+        content = json.loads(response.content)
+
+        self.assertEqual(
+            content,
+            {
+                "bulk_start_time": ["This field is required."],
+                "bulk_end_time": ["This field is required."],
+                "weekdays": ["This field is required."]
+            }
+        )
+
+    @responses.activate
+    def test_create_batch_retreat(self):
+        """
+        Ensure we can create a batch of retreat if everything is perfect.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        responses.add(
+            responses.POST,
+            "http://example.com/authentication",
+            json={"token": "1234567890"},
+            status=200
+        )
+
+        responses.add(
+            responses.POST,
+            "http://example.com/tasks",
+            status=200
+        )
+
+        data = {
+            'seats': 40,
+            'details': "short_description",
+            'timezone': "America/Montreal",
+            'price': '100.00',
+            'min_day_refund': 7,
+            'min_day_exchange': 7,
+            'refund_rate': 50,
+            'hidden': False,
+            'description': None,
+            'sub_title': None,
+            'postal_code': None,
+            'place_name': None,
+            'type': reverse(
+                'retreat:retreattype-detail',
+                args=[self.retreatType.id]
+            ),
+            'bulk_start_time': '2021-03-01T08:00:00Z',
+            'bulk_end_time': '2021-03-30T12:00:00Z',
+            'weekdays': [0, 1, 2]
+        }
+
+        response = self.client.post(
+            reverse('retreat:retreat-batch-create'),
+            data,
+            format='json',
+        )
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            response.content
+        )
+
+        content = json.loads(response.content)
+
+        self.assertEqual(
+            len(content),
+            14,
+        )
+
+        attributes = self.ATTRIBUTES + [
+            'state_province_fr',
+            'old_id',
+            'details_en',
+            'details_fr',
+            'address_line2_en',
+            'name_en',
+            'name_fr',
+            'state_province_en',
+            'country_fr',
+            'country_en',
+            'city_en',
+            'address_line2_fr',
+            'address_line1_fr',
+            'city_fr',
+            'address_line1_en',
+        ]
+
+        for item in content:
+            self.assertEqual(item['name'][-2:], 'AM', item)
+            self.check_attributes(item, attributes)
+
+    @override_settings(
+        EXTERNAL_SCHEDULER={
+            'URL': "http://example.com",
+            'USER': "user",
+            'PASSWORD': "password",
+        }
+    )
+    @responses.activate
     def test_create_without_toilet_gendered_and_room_type(self):
         """
         Ensure we can create a retreat if user has permission.

--- a/retirement/views.py
+++ b/retirement/views.py
@@ -1,7 +1,9 @@
 import json
 from datetime import datetime, timedelta
-
+import time
+import locale
 import pytz
+from dateutil.rrule import rrule, DAILY
 from django.core.files.base import ContentFile
 from django.db.models import (
     F,
@@ -79,7 +81,7 @@ from .resources import (
 from .serializers import (
     RetreatTypeSerializer,
     AutomaticEmailSerializer,
-    RetreatDateSerializer,
+    RetreatDateSerializer, BatchRetreatSerializer,
 )
 from .services import (
     send_retreat_reminder_email,
@@ -162,6 +164,76 @@ class RetreatViewSet(ExportMixin, viewsets.ModelViewSet):
             instance.is_active = False
             instance.save()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @transaction.atomic()
+    @action(methods=['post'], detail=False, permission_classes=[IsAdminUser])
+    def batch_create(self, request):
+        """
+        This custom action allows an admin to batch create timeslots.
+        :param request:
+        :return:
+        """
+        serializer = BatchRetreatSerializer(data=self.request.data)
+        serializer.is_valid(raise_exception=True)
+        validated_data = serializer.validated_data
+
+        # Create a list of start times for timeslots
+        # Naive datetimes are used to avoid problems with DST (not handled by
+        # rrule)
+        retreat_start_dates = list(
+            rrule(
+                freq=DAILY,
+                dtstart=validated_data.get('bulk_start_time').replace(tzinfo=None),
+                until=validated_data.get('bulk_end_time').replace(tzinfo=None),
+                byweekday=validated_data['weekdays'],
+            )
+        )
+
+        # Create a list of end times for timeslots
+        # Naive datetimes are used to avoid problems with DST (not handled by
+        # rrule)
+        retreat_end_dates = list(
+            rrule(
+                freq=DAILY,
+                dtstart=validated_data.get('bulk_start_time').replace(
+                    hour=validated_data.get('bulk_end_time').hour,
+                    minute=validated_data.get('bulk_end_time').minute,
+                    second=validated_data.get('bulk_end_time').second,
+                    tzinfo=None,
+                ),
+                until=validated_data.get('bulk_end_time').replace(tzinfo=None),
+                byweekday=validated_data['weekdays'],
+            )
+        )
+
+        retreat_data_list = list()
+        tz = pytz.timezone('America/Montreal')
+        locale.setlocale(locale.LC_TIME, "fr_CA")
+        validated_data.pop('bulk_start_time')
+        validated_data.pop('bulk_end_time')
+        validated_data.pop('weekdays')
+
+        for start, end in zip(retreat_start_dates, retreat_end_dates):
+            if tz.localize(start).hour < 12:
+                suffix = 'AM'
+            else:
+                suffix = 'PM'
+            validated_data['name'] = tz.localize(start).strftime("Bloc %d %b") + ' ' + suffix
+            new_retreat = Retreat.objects.create(**validated_data)
+            RetreatDate.objects.create(
+                retreat=new_retreat,
+                start_time=tz.localize(start),
+                end_time=tz.localize(end),
+            )
+            new_retreat.activate()
+            retreat_data_list.append(new_retreat)
+
+        response = self.get_serializer(retreat_data_list, many=True).data
+
+        return Response(
+            status=status.HTTP_200_OK,
+            data=response
+        )
 
     @action(detail=True, permission_classes=[IsAdminUser], methods=['post'])
     def activate(self, request, pk=None):


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Features
| Tickets (_issues_) concerned               | [Ticket 2520](https://redmine.fjnr.ca/issues/2520)

---

##### What have you changed ?
Add bulk creation for virtual bloc

##### How did you change it ?
 - Added a new action viewset and special validation in a custom serializer for bulk creation.
 - Added auto-generation of the name based on type and date of the retreat

##### Is there a special consideration?
Bulk creation work only for type bloc virtual

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [x] My additions are I18N
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 -  [x] I added or modified the documentation