### PR TITLE
Fix calculation of remaining stock. Update tests

### DIFF
--- a/store/models.py
+++ b/store/models.py
@@ -573,10 +573,11 @@ class OptionProduct(BaseProduct):
         if self.manage_stock:
             from retirement.models import Reservation
             refunded_order_lines = Reservation.objects.filter(is_active=False).values_list('order_line', flat=True)
-            remaining_quantity = OrderLineBaseProduct.objects.filter(option=self)\
+            ordered_quantity = OrderLineBaseProduct.objects.filter(option=self)\
                 .exclude(order_line__in=refunded_order_lines)\
                 .aggregate(sum=Sum('quantity'))['sum']
-        return remaining_quantity if remaining_quantity else self.stock
+            remaining_quantity -= (ordered_quantity if ordered_quantity else 0)
+        return remaining_quantity
 
     def has_sufficient_stock(self, quantity_required):
         """

--- a/store/tests/tests_viewset_Order.py
+++ b/store/tests/tests_viewset_Order.py
@@ -3741,7 +3741,7 @@ class OrderWithOptionsTests(APITestCase):
             json=SAMPLE_PAYMENT_RESPONSE,
             status=200
         )
-        quantity = 5
+        quantity = 6
 
         data = {
             'payment_token': "CZgD1NlBzPuSefg",


### PR DESCRIPTION
Issue was we were calculating the number of ordered options but not subtracting it to the stock.
Issue was unnoticed because the test checking it was looking on a stock of 10 with 5 orders. ie remaining = ordered so no red flag seen.