### PR TITLE
Implement new serializer and override view to handle list #rm4805

### DIFF
--- a/retirement/serializers.py
+++ b/retirement/serializers.py
@@ -103,6 +103,15 @@ class RetreatDateSerializer(serializers.HyperlinkedModelSerializer):
         }
 
 
+class ListRetreatDateSerializer(serializers.Serializer):
+    start_time = serializers.DateTimeField()
+    end_time = serializers.DateTimeField()
+
+    class Meta:
+        model = RetreatDate
+        fields = ['start_time', 'end_time']
+
+
 class RetreatTypeSerializer(serializers.HyperlinkedModelSerializer):
     id = serializers.ReadOnlyField()
 
@@ -316,6 +325,24 @@ class RetreatSerializer(BaseProductSerializer):
                 'view_name': 'retreat:retreattype-detail',
             },
         }
+
+
+class ListRetreatSerializer(serializers.Serializer):
+    id = serializers.ReadOnlyField()
+    name = serializers.CharField(read_only=True)
+    dates = ListRetreatDateSerializer(
+        source='retreat_dates',
+        many=True,
+        read_only=True,
+    )
+    total_reservations = serializers.ReadOnlyField()
+    seats = serializers.IntegerField(read_only=True)
+    is_active = serializers.BooleanField(read_only=True)
+
+    class Meta:
+        model = Retreat
+        fields = ['id', 'name', 'retreat_dates', 'total_reservations', 'seats', 'is_active']
+        exclude = ('deleted',)
 
 
 class BatchRetreatSerializer(RetreatSerializer):

--- a/retirement/tests/tests_viewset_Retreat.py
+++ b/retirement/tests/tests_viewset_Retreat.py
@@ -1736,6 +1736,7 @@ class RetreatTests(CustomAPITestCase):
         response = self.client.get(
             reverse('retreat:retreat-list'),
             {
+                'ordering': '-display_start_time',
                 'finish_after': '2099-03-01T00:00:00Z',
                 'start_before': '2099-05-01T00:00:00Z',
             },
@@ -1770,6 +1771,7 @@ class RetreatTests(CustomAPITestCase):
         response = self.client.get(
             reverse('retreat:retreat-list'),
             {
+                'ordering': '-display_start_time',
                 'finish_after': '2099-05-01T00:00:00Z',
             },
             format='json',

--- a/retirement/tests/tests_viewset_Retreat.py
+++ b/retirement/tests/tests_viewset_Retreat.py
@@ -99,6 +99,14 @@ class RetreatTests(CustomAPITestCase):
         'hide_from_client_admin_panel',
         'require_purchase_room',
     ]
+    LIST_ATTRIBUTES = [
+        'id',
+        'name',
+        'seats',
+        'is_active',
+        'total_reservations',
+        'dates',
+    ]
 
     @classmethod
     def setUpClass(cls):
@@ -996,9 +1004,11 @@ class RetreatTests(CustomAPITestCase):
         content = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(content['results']), 1)
 
+        attributes = self.LIST_ATTRIBUTES
         for item in content['results']:
-            self.check_attributes(item)
+            self.check_attributes(item, attributes)
 
     def test_list_with_search(self):
         """
@@ -1023,23 +1033,7 @@ class RetreatTests(CustomAPITestCase):
 
         self.assertEqual(len(content['results']), 1)
 
-        attributes = self.ATTRIBUTES + [
-            'state_province_fr',
-            'old_id',
-            'details_en',
-            'details_fr',
-            'address_line2_en',
-            'name_en',
-            'name_fr',
-            'state_province_en',
-            'country_fr',
-            'country_en',
-            'city_en',
-            'address_line2_fr',
-            'address_line1_fr',
-            'city_fr',
-            'address_line1_en',
-        ]
+        attributes = self.LIST_ATTRIBUTES
         for item in content['results']:
             self.check_attributes(item, attributes)
 
@@ -1102,23 +1096,7 @@ class RetreatTests(CustomAPITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        attributes = self.ATTRIBUTES + [
-            'state_province_fr',
-            'old_id',
-            'details_en',
-            'details_fr',
-            'address_line2_en',
-            'name_en',
-            'name_fr',
-            'state_province_en',
-            'country_fr',
-            'country_en',
-            'city_en',
-            'address_line2_fr',
-            'address_line1_fr',
-            'city_fr',
-            'address_line1_en',
-        ]
+        attributes = self.LIST_ATTRIBUTES
         for item in content['results']:
             self.check_attributes(item, attributes)
 
@@ -1550,3 +1528,271 @@ class RetreatTests(CustomAPITestCase):
             results[0].get('id'),
             retreat_2.id
         )
+
+    def test_list_by_date_interval(self):
+        """
+        Ensure we can filter by end date and start date of retreats
+        """
+        Retreat.objects.all().delete()
+
+        retreat_1 = Retreat.objects.create(
+            name="retreat_started",
+            price=199,
+            type=self.retreatType,
+            seats=2,
+            min_day_refund=2,
+            min_day_exchange=2,
+            refund_rate=20,
+            display_start_time=LOCAL_TIMEZONE.localize(
+                datetime(2099, 1, 3),
+            ),
+        )
+        RetreatDate.objects.create(
+            start_time='2099-01-03T00:00:00Z',
+            end_time='2099-04-01T00:00:00Z',
+            retreat=retreat_1,
+        )
+        RetreatDate.objects.create(
+            start_time='2099-04-01T00:00:00Z',
+            end_time='2099-04-20T00:00:00Z',
+            retreat=retreat_1,
+        )
+        RetreatDate.objects.create(
+            start_time='2099-05-01T00:00:00Z',
+            end_time='2099-06-01T00:00:00Z',
+            retreat=retreat_1,
+        )
+        retreat_1.activate()
+
+        retreat_2 = Retreat.objects.create(
+            name="retreat_started",
+            price=199,
+            type=self.retreatType,
+            seats=2,
+            min_day_refund=2,
+            min_day_exchange=2,
+            refund_rate=20,
+            display_start_time=LOCAL_TIMEZONE.localize(
+                datetime(2099, 1, 1),
+            ),
+        )
+        RetreatDate.objects.create(
+            start_time='2099-01-01T00:00:00Z',
+            end_time='2099-02-01T00:00:00Z',
+            retreat=retreat_2,
+        )
+        RetreatDate.objects.create(
+            start_time='2099-03-23T00:00:00Z',
+            end_time='2099-04-20T00:00:00Z',
+            retreat=retreat_2,
+        )
+        RetreatDate.objects.create(
+            start_time='2099-05-20T00:00:00Z',
+            end_time='2099-06-01T00:00:00Z',
+            retreat=retreat_2,
+        )
+        retreat_2.activate()
+
+        retreat_3 = Retreat.objects.create(
+            name="retreat_started",
+            price=199,
+            type=self.retreatType,
+            seats=2,
+            min_day_refund=2,
+            min_day_exchange=2,
+            refund_rate=20,
+            display_start_time=LOCAL_TIMEZONE.localize(
+                datetime(2099, 1, 2),
+            ),
+        )
+        RetreatDate.objects.create(
+            start_time='2099-01-02T00:00:00Z',
+            end_time='2099-06-01T00:00:00Z',
+            retreat=retreat_3,
+        )
+        retreat_3.activate()
+
+        retreat_4 = Retreat.objects.create(
+            name="retreat_started",
+            price=199,
+            type=self.retreatType,
+            seats=2,
+            min_day_refund=2,
+            min_day_exchange=2,
+            refund_rate=20,
+            display_start_time=LOCAL_TIMEZONE.localize(
+                datetime(2099, 1, 1),
+            ),
+        )
+        RetreatDate.objects.create(
+            start_time='2099-01-04T00:00:00Z',
+            end_time='2099-01-05T00:00:00Z',
+            retreat=retreat_4,
+        )
+        RetreatDate.objects.create(
+            start_time='2099-01-03T00:00:00Z',
+            end_time='2099-01-04T00:00:00Z',
+            retreat=retreat_4,
+        )
+        retreat_4.activate()
+
+        retreat_5 = Retreat.objects.create(
+            name="retreat_started",
+            price=199,
+            type=self.retreatType,
+            seats=2,
+            min_day_refund=2,
+            min_day_exchange=2,
+            refund_rate=20,
+            display_start_time=LOCAL_TIMEZONE.localize(
+                datetime(2099, 6, 1),
+            ),
+        )
+        RetreatDate.objects.create(
+            start_time='2099-06-01T00:00:00Z',
+            end_time='2099-06-02T00:00:00Z',
+            retreat=retreat_5,
+        )
+        RetreatDate.objects.create(
+            start_time='2099-06-03T00:00:00Z',
+            end_time='2099-06-04T00:00:00Z',
+            retreat=retreat_5,
+        )
+        retreat_5.activate()
+
+        retreat_6 = Retreat.objects.create(
+            name="retreat_started",
+            price=199,
+            type=self.retreatType,
+            seats=2,
+            min_day_refund=2,
+            min_day_exchange=2,
+            refund_rate=20,
+            display_start_time=LOCAL_TIMEZONE.localize(
+                datetime(2099, 3, 10),
+            ),
+        )
+        RetreatDate.objects.create(
+            start_time='2099-03-10T00:00:00Z',
+            end_time='2099-03-11T00:00:00Z',
+            retreat=retreat_6,
+        )
+        RetreatDate.objects.create(
+            start_time='2099-04-03T00:00:00Z',
+            end_time='2099-04-04T00:00:00Z',
+            retreat=retreat_6,
+        )
+        retreat_6.activate()
+
+        retreat_7 = Retreat.objects.create(
+            name="retreat_started",
+            price=199,
+            type=self.retreatType,
+            seats=2,
+            min_day_refund=2,
+            min_day_exchange=2,
+            refund_rate=20,
+            display_start_time=LOCAL_TIMEZONE.localize(
+                datetime(2099, 2, 10),
+            ),
+        )
+        RetreatDate.objects.create(
+            start_time='2099-02-10T00:00:00Z',
+            end_time='2099-03-11T00:00:00Z',
+            retreat=retreat_7,
+        )
+        RetreatDate.objects.create(
+            start_time='2099-04-03T00:00:00Z',
+            end_time='2099-04-04T00:00:00Z',
+            retreat=retreat_7,
+        )
+        retreat_7.activate()
+
+        retreat_8 = Retreat.objects.create(
+            name="retreat_started",
+            price=199,
+            type=self.retreatType,
+            seats=2,
+            min_day_refund=2,
+            min_day_exchange=2,
+            refund_rate=20,
+            display_start_time=LOCAL_TIMEZONE.localize(
+                datetime(2099, 3, 11),
+            ),
+        )
+        RetreatDate.objects.create(
+            start_time='2099-03-11T00:00:00Z',
+            end_time='2099-03-12T00:00:00Z',
+            retreat=retreat_8,
+        )
+        RetreatDate.objects.create(
+            start_time='2099-06-03T00:00:00Z',
+            end_time='2099-06-04T00:00:00Z',
+            retreat=retreat_8,
+        )
+        retreat_8.activate()
+
+        # Interval
+        response = self.client.get(
+            reverse('retreat:retreat-list'),
+            {
+                'finish_after': '2099-03-01T00:00:00Z',
+                'start_before': '2099-05-01T00:00:00Z',
+            },
+            format='json',
+        )
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            response.content
+        )
+
+        content = response.json()
+        results = content.get('results')
+        id_results = [x['id'] for x in results]
+        self.assertEqual(len(results), 6)
+        self.assertTrue(retreat_1.id in id_results)
+        self.assertTrue(retreat_2.id in id_results)
+        self.assertTrue(retreat_3.id in id_results)
+        self.assertTrue(retreat_6.id in id_results)
+        self.assertTrue(retreat_7.id in id_results)
+        self.assertTrue(retreat_8.id in id_results)
+
+        self.assertEqual(results[5].get('id'), retreat_2.id)
+        self.assertEqual(results[4].get('id'), retreat_3.id)
+        self.assertEqual(results[3].get('id'), retreat_1.id)
+        self.assertEqual(results[2].get('id'), retreat_7.id)
+        self.assertEqual(results[1].get('id'), retreat_6.id)
+        self.assertEqual(results[0].get('id'), retreat_8.id)
+
+        # Hide past retreat
+        response = self.client.get(
+            reverse('retreat:retreat-list'),
+            {
+                'finish_after': '2099-05-01T00:00:00Z',
+            },
+            format='json',
+        )
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            response.content
+        )
+
+        content = response.json()
+        results = content.get('results')
+        self.assertEqual(len(results), 5)
+        id_results = [x['id'] for x in results]
+        self.assertTrue(retreat_1.id in id_results)
+        self.assertTrue(retreat_2.id in id_results)
+        self.assertTrue(retreat_3.id in id_results)
+        self.assertTrue(retreat_5.id in id_results)
+        self.assertTrue(retreat_8.id in id_results)
+
+        self.assertEqual(results[4].get('id'), retreat_2.id)
+        self.assertEqual(results[3].get('id'), retreat_3.id)
+        self.assertEqual(results[2].get('id'), retreat_1.id)
+        self.assertEqual(results[1].get('id'), retreat_8.id)
+        self.assertEqual(results[0].get('id'), retreat_5.id)

--- a/retirement/views.py
+++ b/retirement/views.py
@@ -164,19 +164,25 @@ class RetreatViewSet(ExportMixin, viewsets.ModelViewSet):
     create:
     Create a new retreat instance.
     """
-    serializer_class = serializers.RetreatSerializer
     queryset = Retreat.objects.all()
     permission_classes = (
         permissions.IsAdminOrReadOnly,
     )
-
     ordering = [
         'name',
     ]
+    ordering_fields = (
+        'display_start_time',
+    )
 
     filter_class = RetreatFilter
     search_fields = ('name',)
     export_resource = RetreatResource()
+
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return serializers.ListRetreatSerializer
+        return serializers.RetreatSerializer
 
     def get_queryset(self):
         """
@@ -217,20 +223,6 @@ class RetreatViewSet(ExportMixin, viewsets.ModelViewSet):
                 display_start_time__gte=display_start_time_gte
             )
         return queryset
-
-    def list(self, request, *args, **kwargs):
-        """
-        Override DRF list to change serializer with fewer data
-        """
-        serializer = ListRetreatSerializer
-        queryset = self.filter_queryset(self.get_queryset())\
-            .order_by('-display_start_time')
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = serializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-        serializer = serializer(queryset, many=True)
-        return Response(serializer.data)
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()


### PR DESCRIPTION
Tests added, one more filter in the filter class for period

| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Feature
| Tickets (_issues_) concerned               | 4805

---

##### What have you changed ?
Reduce number of fields sent for a list of retreats, implement date filter 

##### How did you change it ?
Create new serializer, override ViewSet and add new filter

##### Is there a special consideration?
Nope

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [x] My additions are I18N
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 -  [x] I added or modified the documentation