### PR TITLE
Feature filter date period #rm4845

### DIFF
--- a/workplace/tests/tests_viewset_Period.py
+++ b/workplace/tests/tests_viewset_Period.py
@@ -701,6 +701,44 @@ class PeriodTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_admin_list_date_filter(self):
+        """
+        Ensure we can list periods as admin with date filter
+        """
+        client = APIClient()
+        client.force_authenticate(user=self.admin)
+
+        period1 = Period.objects.create(
+            name="current_period",
+            workplace=self.workplace,
+            start_date='2100-01-01T00:00:00Z',
+            end_date='2100-01-03T00:00:00Z',
+            price=3,
+            is_active=False,
+        )
+        period2 = Period.objects.create(
+            name="random_period2",
+            workplace=self.workplace,
+            start_date='2100-01-03T00:00:00Z',
+            end_date='2100-01-05T00:00:00Z',
+            price=3,
+            is_active=False,
+        )
+
+        response = client.get(
+            reverse('period-list'),
+            {
+                'start_date_lte': '2100-01-02T00:00:00Z',
+                'end_date_gte': '2100-01-02T00:00:00Z',
+            },
+            format='json',
+        )
+
+        data = json.loads(response.content)
+        self.assertEqual(len(data['results']), 1)
+        self.assertEqual(data['results'][0]['name'], period1.name)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_list_inactive(self):
         """
         Ensure we can list all periods as an admin user.

--- a/workplace/views.py
+++ b/workplace/views.py
@@ -100,14 +100,47 @@ class PeriodViewSet(ExportMixin, viewsets.ModelViewSet):
 
     export_resource = PeriodResource()
 
+    def _filter_date_queryset(self, queryset):
+        """
+        Apply date filter on queryset
+        """
+        start_date_lte = self.request.query_params.get(
+            'start_date_lte',
+            None,
+        )
+        end_date_gte = self.request.query_params.get(
+            'end_date_gte',
+            None,
+        )
+        start_date_gte = self.request.query_params.get(
+            'start_date_gte',
+            None,
+        )
+        end_date_lte = self.request.query_params.get(
+            'end_date_lte',
+            None,
+        )
+        if start_date_lte:
+            queryset = queryset.filter(start_date__lte=start_date_lte)
+        if end_date_gte:
+            queryset = queryset.filter(end_date__gte=end_date_gte)
+        if start_date_gte:
+            queryset = queryset.filter(start_date__gte=start_date_gte)
+        if end_date_lte:
+            queryset = queryset.filter(end_date__lte=end_date_lte)
+        return queryset
+
     def get_queryset(self):
         """
         This viewset should return active periods except if
         the currently authenticated user is an admin (is_staff).
         """
         if self.request.user.is_staff:
-            return Period.objects.all()
-        return Period.objects.filter(is_active=True)
+            queryset = Period.objects.all()
+        else:
+            queryset = Period.objects.filter(is_active=True)
+
+        return self._filter_date_queryset(queryset)
 
     def destroy(self, request, *args, **kwargs):
         """


### PR DESCRIPTION
Add filter for period object. Note that to filter current period, with the prevention of overlapping, simply put start_date_lte and end_date_gte equal to today's date