### PR TITLE
Feature retreat deletion #rm4813

### DIFF
--- a/blitz_api/settings.py
+++ b/blitz_api/settings.py
@@ -366,7 +366,12 @@ ANYMAIL = {
             'EXPORT_DONE',
             default='67',
             cast=int
-        )
+        ),
+        'RETREAT_DELETED': config(
+            'RETREAT_DELETED',
+            default='68',
+            cast=int
+        ),
     },
 }
 EMAIL_BACKEND = config('EMAIL_BACKEND',

--- a/retirement/models.py
+++ b/retirement/models.py
@@ -7,19 +7,27 @@ from operator import itemgetter
 
 import requests
 from django.conf import settings
-from django.core.mail import mail_admins, send_mail
+from django.core.mail import mail_admins
+from django.core.mail import send_mail as django_send_mail
+from django.template.loader import render_to_string
 from django.utils import timezone
+
+from rest_framework import serializers as rest_framework_serializers
 
 from blitz_api.services import send_mail as send_templated_email
 from blitz_api.cron_manager_api import CronManager
 from blitz_api.models import Address
 from django.contrib.auth import get_user_model
-from django.db import models
+from django.db import models, transaction
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 from safedelete.models import SafeDeleteModel
 from simple_history.models import HistoricalRecords
 
+from log_management.models import (
+    Log,
+    EmailLog,
+)
 from store.models import (
     Membership,
     OrderLine,
@@ -30,6 +38,8 @@ from store.models import (
     Refund,
 )
 from store.services import refund_amount
+from store.exceptions import PaymentAPIError
+from store.services import PAYSAFE_EXCEPTION
 
 User = get_user_model()
 TAX_RATE = settings.LOCAL_SETTINGS['SELLING_TAX']
@@ -1066,6 +1076,12 @@ class Reservation(SafeDeleteModel):
         verbose_name=_("User"),
         related_name='retreat_reservations',
     )
+    REFUND_REASON = {
+        'U': "Reservation canceled",
+        'RD': "Retreat deleted",
+        'RM': "Retreat modified",
+        'A': "Reservation canceled",
+    }
     retreat = models.ForeignKey(
         Retreat,
         on_delete=models.CASCADE,
@@ -1184,6 +1200,166 @@ class Reservation(SafeDeleteModel):
             refund_id=refund_res_content['id'],
         )
         return refund
+
+    def send_refund_confirmation_email(self, amount, retreat, order, user,
+                                       total_amount, amount_tax):
+        # Here the price takes the applied coupon into account, if
+        # applicable.
+        old_retreat = {
+            'price': (amount * retreat.refund_rate) / 100,
+            'name': "{0}: {1}".format(
+                _("Retreat"),
+                retreat.name
+            )
+        }
+
+        # Send order confirmation email
+        merge_data = {
+            'DATETIME': timezone.localtime().strftime("%x %X"),
+            'ORDER_ID': order.id,
+            'CUSTOMER_NAME': user.first_name + " " + user.last_name,
+            'CUSTOMER_EMAIL': user.email,
+            'CUSTOMER_NUMBER': user.id,
+            'TYPE': "Remboursement",
+            'OLD_RETREAT': old_retreat,
+            'COST': total_amount,
+            'TAX': amount_tax,
+        }
+
+        plain_msg = render_to_string("refund.txt", merge_data)
+        msg_html = render_to_string("refund.html", merge_data)
+
+        try:
+            response_send_mail = django_send_mail(
+                "Confirmation de remboursement",
+                plain_msg,
+                settings.DEFAULT_FROM_EMAIL,
+                [user.email],
+                html_message=msg_html,
+            )
+
+            EmailLog.add(user.email, 'refund', response_send_mail)
+        except Exception as err:
+            additional_data = {
+                'title': "Confirmation de votre nouvelle adresse courriel",
+                'default_from': settings.DEFAULT_FROM_EMAIL,
+                'user_email': user.email,
+                'merge_data': merge_data,
+                'template': 'notify_user_of_change_email'
+            }
+            Log.error(
+                source='SENDING_BLUE_TEMPLATE',
+                message=err,
+                additional_data=json.dumps(additional_data)
+            )
+            raise
+
+    def process_refund(self, cancel_reason, force_refund):
+        """
+        User will be refund the retreat's "refund_rate" if we're at least
+        "min_day_refund" days before the event.
+
+        By canceling 'min_day_refund' days or more before the event, the user
+         will be refunded 'refund_rate'% of the price paid.
+        The user will receive an email confirming the refund or inviting the
+         user to contact the support if his payment information are no longer
+         valid.
+        If the user cancels less than 'min_day_refund' days before the event,
+         no refund is made unless forced by admin.
+
+        Taxes are refunded proportionally to refund_rate.
+        """
+        retreat = self.retreat
+        user = self.user
+        reservation_active = self.is_active
+        order_line = self.order_line
+        if order_line:
+            order = order_line.order
+            refundable = self.refundable
+        else:
+            order = None
+            refundable = False
+        respects_minimum_days = (
+                (retreat.start_time - timezone.now()) >=
+                timedelta(days=retreat.min_day_refund))
+
+        # In order to process a refund we need to be in one of those
+        # two cases:
+        #
+        #  1 - We respect the date limit to be refund and the retreat is
+        #  refundable
+        #
+        #  2 - An admin want to force a refund and the user paid for
+        #  his reservation
+        #
+        # In all case, only paid reservation (amount > 0) can be refunded
+        if self.get_refund_value() > 0:
+            process_refund = (respects_minimum_days and refundable) or \
+                             force_refund
+        else:
+            process_refund = False
+
+        with transaction.atomic():
+            # No need to check for previous refunds because a refunded
+            # reservation is automatically canceled, thus not active.
+            if reservation_active:
+                if order_line and order_line.quantity > 1:
+                    raise rest_framework_serializers.ValidationError({
+                        'non_field_errors': [_(
+                            "The order containing this reservation has a "
+                            "quantity bigger than 1. Please contact the "
+                            "support team."
+                        )]
+                    })
+                if process_refund:
+                    try:
+                        refund = self.make_refund(
+                            self.REFUND_REASON[cancel_reason])
+                    except PaymentAPIError as err:
+                        if str(err) == PAYSAFE_EXCEPTION['3406']:
+                            raise rest_framework_serializers.ValidationError({
+                                'non_field_errors': [_(
+                                    "The order has not been charged yet. Try "
+                                    "again later."
+                                )],
+                                'detail': err.detail
+                            })
+                        raise rest_framework_serializers.ValidationError(
+                            {
+                                'message': str(err),
+                                'non_field_errors': [_(
+                                    "An error occured with the payment system."
+                                    " Please try again later."
+                                )],
+                                'detail': err.detail
+                            }
+                        )
+                    self.cancelation_action = 'R'
+                else:
+                    self.cancelation_action = 'N'
+                self.is_active = False
+
+                self.cancelation_reason = cancel_reason
+                self.cancelation_date = timezone.now()
+                self.save()
+
+                # free seat unless retreat is deleted
+                if cancel_reason != 'RD':
+                    free_seats = retreat.places_remaining
+                    if retreat.reserved_seats or free_seats == 1:
+                        retreat.add_wait_queue_place(user)
+                    retreat.save()
+
+        # Send an email if a refund has been issued
+        if reservation_active and self.cancelation_action == 'R':
+            self.send_refund_confirmation_email(
+                amount=round(refund.amount - refund.amount * TAX_RATE, 2),
+                retreat=retreat,
+                order=order,
+                user=user,
+                total_amount=refund.amount,
+                amount_tax=round(refund.amount * TAX_RATE, 2),
+            )
 
 
 class RetreatUsageLog(models.Model):

--- a/retirement/models.py
+++ b/retirement/models.py
@@ -1251,11 +1251,11 @@ class Reservation(SafeDeleteModel):
             EmailLog.add(user.email, 'refund', response_send_mail)
         except Exception as err:
             additional_data = {
-                'title': "Confirmation de votre nouvelle adresse courriel",
+                'title': "Confirmation de remboursement",
                 'default_from': settings.DEFAULT_FROM_EMAIL,
                 'user_email': user.email,
                 'merge_data': merge_data,
-                'template': 'notify_user_of_change_email'
+                'template': 'refund.html'
             }
             Log.error(
                 source='SENDING_BLUE_TEMPLATE',

--- a/retirement/serializers.py
+++ b/retirement/serializers.py
@@ -492,8 +492,10 @@ class ReservationSerializer(serializers.HyperlinkedModelSerializer):
             instance = Reservation.objects.get(id=instance_pk)
 
             canceled_reservation.is_active = False
-            canceled_reservation.cancelation_reason = 'U'
-            canceled_reservation.cancelation_action = 'E'
+            canceled_reservation.cancelation_reason = \
+                Reservation.CANCELATION_REASON_USER_CANCELLED
+            canceled_reservation.cancelation_action = \
+                Reservation.CANCELATION_ACTION_EXCHANGE
             canceled_reservation.cancelation_date = timezone.now()
             canceled_reservation.save()
 

--- a/retirement/services.py
+++ b/retirement/services.py
@@ -387,7 +387,7 @@ def send_deleted_retreat_email(retreat, users_emails, deletion_message):
         'MESSAGE': deletion_message,
     }
 
-    response_send_mail = send_email_from_template_id(
+    response_send_mail = send_templated_email(
         users_emails,
         context,
         'RETREAT_DELETED'

--- a/retirement/services.py
+++ b/retirement/services.py
@@ -374,3 +374,22 @@ def send_automatic_email(user, retreat, email):
         email.template_id
     )
     return response_send_mail
+
+
+def send_deleted_retreat_email(retreat, users_emails, deletion_message):
+    """
+    This function sends an automatic email to notify all registered users
+    of a retreat that it has been deleted
+    """
+
+    context = {
+        'RETREAT_NAME': retreat.name_fr,
+        'MESSAGE': deletion_message,
+    }
+
+    response_send_mail = send_email_from_template_id(
+        users_emails,
+        context,
+        'RETREAT_DELETED'
+    )
+    return response_send_mail

--- a/retirement/tests/tests_model_Retreat.py
+++ b/retirement/tests/tests_model_Retreat.py
@@ -19,6 +19,7 @@ from retirement.models import (
     Retreat,
     RetreatDate,
     RetreatType,
+    Reservation,
 )
 from store.models import (
     OptionProduct
@@ -682,3 +683,28 @@ class RetreatTests(APITestCase):
         for user in distribution:
             room_set.add(user['room_number'])
         self.assertEqual(len(room_set), 9)
+
+    def test_get_participants_emails(self):
+        user = UserFactory(email='email@1')
+        user2 = UserFactory(email='email@2')
+        user3 = UserFactory(email='email@3')
+
+        Reservation.objects.create(
+            user=user,
+            retreat=self.retreat,
+            is_active=True,
+        )
+        Reservation.objects.create(
+            user=user2,
+            retreat=self.retreat,
+            is_active=True,
+        )
+        Reservation.objects.create(
+            user=user3,
+            retreat=self.retreat,
+            is_active=False,
+        )
+        emails = self.retreat.get_participants_emails()
+        self.assertEqual(2, len(emails))
+        self.assertTrue(user.email in emails)
+        self.assertTrue(user2.email in emails)

--- a/retirement/tests/tests_viewset_Reservation.py
+++ b/retirement/tests/tests_viewset_Reservation.py
@@ -953,8 +953,14 @@ class ReservationTests(CustomAPITestCase):
         self.reservation.refresh_from_db()
 
         self.assertFalse(self.reservation.is_active)
-        self.assertEqual(self.reservation.cancelation_reason, 'U')
-        self.assertEqual(self.reservation.cancelation_action, 'R')
+        self.assertEqual(
+            self.reservation.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
+        self.assertEqual(
+            self.reservation.cancelation_action,
+            Reservation.CANCELATION_ACTION_REFUND
+        )
         self.assertEqual(self.reservation.cancelation_date, FIXED_TIME)
 
         self.reservation.is_active = True
@@ -1018,8 +1024,14 @@ class ReservationTests(CustomAPITestCase):
         free_reservation.refresh_from_db()
 
         self.assertFalse(free_reservation.is_active)
-        self.assertEqual(free_reservation.cancelation_reason, 'U')
-        self.assertEqual(free_reservation.cancelation_action, 'N')
+        self.assertEqual(
+            free_reservation.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
+        self.assertEqual(
+            free_reservation.cancelation_action,
+            Reservation.CANCELATION_ACTION_NONE
+        )
         self.assertEqual(free_reservation.cancelation_date, FIXED_TIME)
 
         free_reservation.is_active = True
@@ -1058,8 +1070,14 @@ class ReservationTests(CustomAPITestCase):
         self.reservation.refresh_from_db()
 
         self.assertFalse(self.reservation.is_active)
-        self.assertEqual(self.reservation.cancelation_reason, 'U')
-        self.assertEqual(self.reservation.cancelation_action, 'N')
+        self.assertEqual(
+            self.reservation.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
+        self.assertEqual(
+            self.reservation.cancelation_action,
+            Reservation.CANCELATION_ACTION_NONE
+        )
         self.assertEqual(self.reservation.cancelation_date, FIXED_TIME)
 
         self.reservation.is_active = True
@@ -1101,8 +1119,14 @@ class ReservationTests(CustomAPITestCase):
         self.reservation.refresh_from_db()
 
         self.assertFalse(self.reservation.is_active)
-        self.assertEqual(self.reservation.cancelation_reason, 'U')
-        self.assertEqual(self.reservation.cancelation_action, 'N')
+        self.assertEqual(
+            self.reservation.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
+        self.assertEqual(
+            self.reservation.cancelation_action,
+            Reservation.CANCELATION_ACTION_NONE
+        )
         self.assertEqual(self.reservation.cancelation_date, FIXED_TIME)
 
         self.reservation.is_active = True
@@ -1150,8 +1174,14 @@ class ReservationTests(CustomAPITestCase):
         self.reservation2.refresh_from_db()
 
         self.assertFalse(self.reservation2.is_active)
-        self.assertEqual(self.reservation2.cancelation_reason, 'U')
-        self.assertEqual(self.reservation2.cancelation_action, 'N')
+        self.assertEqual(
+            self.reservation2.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
+        self.assertEqual(
+            self.reservation2.cancelation_action,
+            Reservation.CANCELATION_ACTION_NONE
+        )
         self.assertEqual(self.reservation2.cancelation_date, FIXED_TIME)
 
         self.reservation2.is_active = True
@@ -1201,8 +1231,14 @@ class ReservationTests(CustomAPITestCase):
         self.reservation2.refresh_from_db()
 
         self.assertFalse(self.reservation2.is_active)
-        self.assertEqual(self.reservation2.cancelation_reason, 'U')
-        self.assertEqual(self.reservation2.cancelation_action, 'N')
+        self.assertEqual(
+            self.reservation2.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
+        self.assertEqual(
+            self.reservation2.cancelation_action,
+            Reservation.CANCELATION_ACTION_NONE
+        )
         self.assertEqual(self.reservation2.cancelation_date, FIXED_TIME)
 
         self.reservation2.is_active = True
@@ -1250,8 +1286,14 @@ class ReservationTests(CustomAPITestCase):
         self.reservation_admin.refresh_from_db()
 
         self.assertFalse(self.reservation_admin.is_active)
-        self.assertEqual(self.reservation_admin.cancelation_reason, 'U')
-        self.assertEqual(self.reservation_admin.cancelation_action, 'R')
+        self.assertEqual(
+            self.reservation_admin.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
+        self.assertEqual(
+            self.reservation_admin.cancelation_action,
+            Reservation.CANCELATION_ACTION_REFUND
+        )
         self.assertEqual(self.reservation_admin.cancelation_date,
                          FIXED_TIME)
 
@@ -1310,8 +1352,14 @@ class ReservationTests(CustomAPITestCase):
         self.reservation.refresh_from_db()
 
         self.assertFalse(self.reservation.is_active)
-        self.assertEqual(self.reservation.cancelation_reason, 'A')
-        self.assertEqual(self.reservation.cancelation_action, 'N')
+        self.assertEqual(
+            self.reservation.cancelation_reason,
+            Reservation.CANCELATION_REASON_ADMIN_CANCELLED
+        )
+        self.assertEqual(
+            self.reservation.cancelation_action,
+            Reservation.CANCELATION_ACTION_NONE
+        )
         self.assertEqual(self.reservation.cancelation_date, FIXED_TIME)
 
         self.reservation.is_active = True
@@ -1383,8 +1431,14 @@ class ReservationTests(CustomAPITestCase):
         self.reservation.refresh_from_db()
 
         self.assertFalse(self.reservation.is_active)
-        self.assertEqual(self.reservation.cancelation_reason, 'U')
-        self.assertEqual(self.reservation.cancelation_action, 'R')
+        self.assertEqual(
+            self.reservation.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
+        self.assertEqual(
+            self.reservation.cancelation_action,
+            Reservation.CANCELATION_ACTION_REFUND
+        )
 
         self.reservation.is_active = True
         self.reservation.cancelation_date = None

--- a/retirement/tests/tests_viewset_Reservation_update.py
+++ b/retirement/tests/tests_viewset_Reservation_update.py
@@ -288,8 +288,14 @@ class ReservationTests(APITestCase):
         canceled_reservation = Reservation.objects.filter(is_active=False)[0]
 
         self.assertTrue(canceled_reservation)
-        self.assertEqual(canceled_reservation.cancelation_action, 'E')
-        self.assertEqual(canceled_reservation.cancelation_reason, 'U')
+        self.assertEqual(
+            canceled_reservation.cancelation_action,
+            Reservation.CANCELATION_ACTION_EXCHANGE
+        )
+        self.assertEqual(
+            canceled_reservation.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
         self.assertEqual(canceled_reservation.cancelation_date, FIXED_TIME)
         self.assertEqual(canceled_reservation.retreat, self.retreat)
         self.assertEqual(canceled_reservation.order_line, self.order_line)
@@ -749,8 +755,14 @@ class ReservationTests(APITestCase):
         canceled_reservation = Reservation.objects.filter(is_active=False)[0]
 
         self.assertTrue(canceled_reservation)
-        self.assertEqual(canceled_reservation.cancelation_action, 'E')
-        self.assertEqual(canceled_reservation.cancelation_reason, 'U')
+        self.assertEqual(
+            canceled_reservation.cancelation_action,
+            Reservation.CANCELATION_ACTION_EXCHANGE
+        )
+        self.assertEqual(
+            canceled_reservation.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
         self.assertEqual(canceled_reservation.cancelation_date, FIXED_TIME)
         self.assertEqual(canceled_reservation.retreat, self.retreat)
         self.assertEqual(canceled_reservation.order_line, self.order_line)
@@ -889,8 +901,14 @@ class ReservationTests(APITestCase):
         canceled_reservation = Reservation.objects.filter(is_active=False)[0]
 
         self.assertTrue(canceled_reservation)
-        self.assertEqual(canceled_reservation.cancelation_action, 'E')
-        self.assertEqual(canceled_reservation.cancelation_reason, 'U')
+        self.assertEqual(
+            canceled_reservation.cancelation_action,
+            Reservation.CANCELATION_ACTION_EXCHANGE
+        )
+        self.assertEqual(
+            canceled_reservation.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
         self.assertEqual(canceled_reservation.cancelation_date, FIXED_TIME)
         self.assertEqual(canceled_reservation.retreat, self.retreat)
         self.assertEqual(canceled_reservation.order_line, self.order_line)
@@ -988,8 +1006,14 @@ class ReservationTests(APITestCase):
         canceled_reservation = Reservation.objects.filter(is_active=False)[0]
 
         self.assertTrue(canceled_reservation)
-        self.assertEqual(canceled_reservation.cancelation_action, 'E')
-        self.assertEqual(canceled_reservation.cancelation_reason, 'U')
+        self.assertEqual(
+            canceled_reservation.cancelation_action,
+            Reservation.CANCELATION_ACTION_EXCHANGE
+        )
+        self.assertEqual(
+            canceled_reservation.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
         self.assertEqual(canceled_reservation.cancelation_date, FIXED_TIME)
         self.assertEqual(canceled_reservation.retreat, self.retreat)
         self.assertEqual(canceled_reservation.order_line, self.order_line)

--- a/retirement/tests/tests_viewset_Retreat.py
+++ b/retirement/tests/tests_viewset_Retreat.py
@@ -31,7 +31,6 @@ from retirement.models import (
     RetreatDate,
     Reservation,
 )
-
 User = get_user_model()
 
 LOCAL_TIMEZONE = pytz.timezone(settings.TIME_ZONE)

--- a/retirement/tests/tests_viewset_Retreat.py
+++ b/retirement/tests/tests_viewset_Retreat.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 from datetime import (
     datetime,
     timedelta,
@@ -28,6 +29,7 @@ from retirement.models import (
     Retreat,
     RetreatType,
     RetreatDate,
+    Reservation,
 )
 
 User = get_user_model()
@@ -96,9 +98,6 @@ class RetreatTests(CustomAPITestCase):
         'hide_from_client_admin_panel',
         'require_purchase_room',
         'available_on_retreat_types',
-        'is_specific_to_community',
-        'community_description',
-        'community_name',
     ]
 
     @classmethod
@@ -1017,9 +1016,10 @@ class RetreatTests(CustomAPITestCase):
             data['community_name'],
         )
 
-    def test_delete(self):
+    def test_delete_without_participants(self):
         """
         Ensure we can delete a retreat (setting is_active to false).
+        without participants
         """
         self.client.force_authenticate(user=self.admin)
 
@@ -1038,6 +1038,85 @@ class RetreatTests(CustomAPITestCase):
 
         self.retreat.refresh_from_db()
         self.assertFalse(self.retreat.is_active)
+        self.assertTrue(self.retreat.hide_from_client_admin_panel)
+
+        self.retreat.is_active = True
+
+    def test_delete_with_participants_no_message(self):
+        """
+        Ensure we can't delete a retreat that has participants
+        without a message.
+        """
+        self.client.force_authenticate(user=self.admin)
+        user = UserFactory()
+        Reservation.objects.create(
+            user=user,
+            retreat=self.retreat,
+            is_active=True,
+        )
+
+        response = self.client.delete(
+            reverse(
+                'retreat:retreat-detail',
+                kwargs={'pk': self.retreat.id},
+            ),
+        )
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_400_BAD_REQUEST,
+            response.content,
+        )
+
+    @patch('retirement.models.Retreat.cancel_participants_reservation')
+    @patch('retirement.services.send_deleted_retreat_email')
+    def test_delete_with_participants(self, mock_email, mock_cancel):
+        """
+        Ensure we can delete a retreat that has participants
+        """
+        self.client.force_authenticate(user=self.admin)
+        deletion_message = 'No more fun.'
+
+        user = UserFactory()
+        user2 = UserFactory()
+
+        Reservation.objects.create(
+            user=user,
+            retreat=self.retreat,
+            is_active=True,
+        )
+        Reservation.objects.create(
+            user=user2,
+            retreat=self.retreat,
+            is_active=True,
+        )
+
+        response = self.client.delete(
+            reverse(
+                'retreat:retreat-detail',
+                kwargs={'pk': self.retreat.id},
+            ),
+            {
+                'deletion_message': deletion_message
+            }
+        )
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_204_NO_CONTENT,
+            response.content,
+        )
+
+        mock_email.assert_called_once_with(
+            self.retreat,
+            self.retreat.get_participants_emails(),
+            deletion_message
+        )
+        mock_cancel.assert_called_once_with(False)
+
+        self.retreat.refresh_from_db()
+        self.assertFalse(self.retreat.is_active)
+        self.assertTrue(self.retreat.hide_from_client_admin_panel)
 
         self.retreat.is_active = True
 

--- a/retirement/tests/tests_viewset_Retreat.py
+++ b/retirement/tests/tests_viewset_Retreat.py
@@ -98,6 +98,9 @@ class RetreatTests(CustomAPITestCase):
         'hide_from_client_admin_panel',
         'require_purchase_room',
         'available_on_retreat_types',
+        'is_specific_to_community',
+        'community_description',
+        'community_name',
     ]
 
     @classmethod

--- a/retirement/views.py
+++ b/retirement/views.py
@@ -620,7 +620,10 @@ class ReservationViewSet(ExportMixin, viewsets.ModelViewSet):
         else:
             cancel_reason = Reservation.CANCELATION_REASON_USER_CANCELLED
 
-        instance.process_refund(cancel_reason, force_refund)
+        refund_data = instance.process_refund(cancel_reason, force_refund)
+        if refund_data:
+            Reservation.send_refund_confirmation_email(refund_data)
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/retirement/views.py
+++ b/retirement/views.py
@@ -221,9 +221,16 @@ class RetreatViewSet(ExportMixin, viewsets.ModelViewSet):
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
+        deletion_message = request.data.get('deletion_message', None)
+        if instance.total_reservations > 0 and not deletion_message:
+            error = {
+                'deletion_message': _("There is at least one participant to "
+                                      "this retreat. Please provide a "
+                                      "deletion message.")
+            }
+            return Response(error, status=status.HTTP_400_BAD_REQUEST)
         if instance.is_active:
-            instance.is_active = False
-            instance.save()
+            instance.custom_delete(deletion_message)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @transaction.atomic()

--- a/retirement/views.py
+++ b/retirement/views.py
@@ -222,6 +222,7 @@ class RetreatViewSet(ExportMixin, viewsets.ModelViewSet):
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
         deletion_message = request.data.get('deletion_message', None)
+        force_refund = request.data.get('force_refund', False)
         if instance.total_reservations > 0 and not deletion_message:
             error = {
                 'deletion_message': _("There is at least one participant to "
@@ -230,7 +231,7 @@ class RetreatViewSet(ExportMixin, viewsets.ModelViewSet):
             }
             return Response(error, status=status.HTTP_400_BAD_REQUEST)
         if instance.is_active:
-            instance.custom_delete(deletion_message)
+            instance.custom_delete(deletion_message, force_refund)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @transaction.atomic()

--- a/retirement/views.py
+++ b/retirement/views.py
@@ -616,9 +616,9 @@ class ReservationViewSet(ExportMixin, viewsets.ModelViewSet):
         if self.request.user.is_staff:
             force_refund = request.data.get('force_refund', False)
         if self.request.user.id != user.id:
-            cancel_reason = 'A'
+            cancel_reason = Reservation.CANCELATION_REASON_ADMIN_CANCELLED
         else:
-            cancel_reason = 'U'
+            cancel_reason = Reservation.CANCELATION_REASON_USER_CANCELLED
 
         instance.process_refund(cancel_reason, force_refund)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/workplace/models.py
+++ b/workplace/models.py
@@ -208,12 +208,16 @@ class TimeSlot(SafeDeleteModel):
 
 class Reservation(SafeDeleteModel):
     """Represents a user registration to a TimeSlot"""
+    CANCELATION_REASON_USER_CANCELLED = 'U'
+    CANCELATION_REASON_TIMESLOT_DELETED = 'TD'
+    CANCELATION_REASON_TIMESLOT_MODIFIED = 'TM'
+    CANCELATION_REASON_ADMIN_CANCELLED = 'A'
 
     CANCELATION_REASON = (
-        ('U', _("User canceled")),
-        ('TD', _("Timeslot deleted")),
-        ('TM', _("Timeslot modified")),
-        ('A', _("Admin canceled")),
+        (CANCELATION_REASON_USER_CANCELLED, _("User canceled")),
+        (CANCELATION_REASON_TIMESLOT_DELETED, _("Timeslot deleted")),
+        (CANCELATION_REASON_TIMESLOT_MODIFIED, _("Timeslot modified")),
+        (CANCELATION_REASON_ADMIN_CANCELLED, _("Admin canceled")),
     )
 
     user = models.ForeignKey(

--- a/workplace/tests/tests_viewset_Reservation.py
+++ b/workplace/tests/tests_viewset_Reservation.py
@@ -936,7 +936,10 @@ class ReservationTests(APITestCase):
         self.reservation.refresh_from_db()
 
         self.assertFalse(self.reservation.is_active)
-        self.assertEqual(self.reservation.cancelation_reason, 'U')
+        self.assertEqual(
+            self.reservation.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
         self.assertEqual(self.reservation.cancelation_date, FIXED_TIME)
 
         self.reservation.is_active = True
@@ -966,7 +969,10 @@ class ReservationTests(APITestCase):
         self.reservation.refresh_from_db()
 
         self.assertFalse(self.reservation.is_active)
-        self.assertEqual(self.reservation.cancelation_reason, 'A')
+        self.assertEqual(
+            self.reservation.cancelation_reason,
+            Reservation.CANCELATION_REASON_ADMIN_CANCELLED
+        )
         self.assertEqual(self.reservation.cancelation_date, FIXED_TIME)
 
         self.reservation.is_active = True
@@ -1019,7 +1025,10 @@ class ReservationTests(APITestCase):
         self.reservation.refresh_from_db()
 
         self.assertFalse(self.reservation.is_active)
-        self.assertEqual(self.reservation.cancelation_reason, 'U')
+        self.assertEqual(
+            self.reservation.cancelation_reason,
+            Reservation.CANCELATION_REASON_USER_CANCELLED
+        )
         self.assertEqual(self.reservation.cancelation_date, FIXED_TIME)
 
         self.reservation.is_active = True

--- a/workplace/views.py
+++ b/workplace/views.py
@@ -531,9 +531,11 @@ class ReservationViewSet(ExportMixin, viewsets.ModelViewSet):
             instance.is_active = False
             instance.cancelation_date = timezone.now()
             if self.request.user.id != user.id:
-                instance.cancelation_reason = 'A'
+                instance.cancelation_reason = \
+                    Reservation.CANCELATION_REASON_ADMIN_CANCELLED
             else:
-                instance.cancelation_reason = 'U'
+                instance.cancelation_reason = \
+                    Reservation.CANCELATION_REASON_USER_CANCELLED
             instance.save()
             if self.request.user.is_staff:
                 ticket_return = request.data.get('ticket_return', False)


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Features
| Tickets (_issues_) concerned               | 4813

---

##### What have you changed ?
An admin can now delete a retreat from admin panel

##### How did you change it ?
Add destroy view, model logic and refactor reservation deletion to be used by model instead of only reservation viewset

##### Is there a special consideration?
No

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [x] My additions are I18N
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 -  [x] I added or modified the documentation