### PR TITLE
Reimplement coupon reuse functionnality #rm4984

### DIFF
--- a/retirement/models.py
+++ b/retirement/models.py
@@ -36,6 +36,7 @@ from store.models import (
     OptionProduct,
     Coupon,
     Refund,
+    CouponUser,
 )
 from store.services import refund_amount
 from store.exceptions import PaymentAPIError
@@ -1366,6 +1367,16 @@ class Reservation(SafeDeleteModel):
                 self.cancelation_reason = cancel_reason
                 self.cancelation_date = timezone.now()
                 self.save()
+
+                # Rollback the coupon number of use if the reservation
+                # was done with a coupon
+                if order_line and order_line.coupon:
+                    coupon_user = CouponUser.objects.get(
+                        user=user,
+                        coupon=order_line.coupon,
+                    )
+                    coupon_user.uses = coupon_user.uses - 1
+                    coupon_user.save()
 
                 # free seat unless retreat is deleted
                 if cancel_reason != self.CANCELATION_REASON_RETREAT_DELETED:


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Features
| Tickets (_issues_) concerned               | 4984

---

##### What have you changed ?
Coupon can be reused after cancellation or deletion of reservation

##### How did you change it ?
Re-use old functionality: https://github.com/FJNR-inc/Blitz-API/commit/ae38335e705cc904b97df0d8abff44ed22462008

##### Is there a special consideration?
...

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [x] My additions are I18N
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 -  [x] I added or modified the documentation