### PR TITLE
Enhancement retreat export room no data #rm4995

### DIFF
--- a/retirement/exports.py
+++ b/retirement/exports.py
@@ -76,6 +76,7 @@ def generate_retreat_participation(
     room_export = retreat.has_room_option
     rooms_data = {}
     to_reorder_lines = []
+    no_room_lines = []
     header = [
         'Nom', 'Prénom', 'Email', 'Statut', "Date d'inscription",
         'Restrictions personnelles', 'Ville', 'Téléphone', 'Genre',
@@ -108,14 +109,18 @@ def generate_retreat_participation(
             line_array[10] = rooms_data[user_id]['gender_preference']
             line_array[11] = rooms_data[user_id]['share_with']
             line_array[12] = rooms_data[user_id]['room_number']
-            to_reorder_lines.append(line_array)
+            if line_array[12] == 'NA':
+                no_room_lines.append(line_array)
+            else:
+                to_reorder_lines.append(line_array)
         else:
             writer.writerow(line_array)  # No ordering if no room
     if room_export:
-        # We need to export in room order
+        # We need to export in room order. User without data are added last
         for ordered_data in sorted(to_reorder_lines, key=lambda x: x[13]):
             writer.writerow(ordered_data)
-
+        for no_room_user_data in no_room_lines:
+            writer.writerow(no_room_user_data)
     date_file = LOCAL_TIMEZONE.localize(datetime.now()) \
         .strftime("%Y%m%d-%H%M%S")
     filename = f'export-participation-{retreat.name}_{date_file}.csv'

--- a/retirement/models.py
+++ b/retirement/models.py
@@ -751,14 +751,21 @@ class Retreat(Address, SafeDeleteModel, BaseProduct):
                 'placed': False
             }
             room_options = OptionProduct.objects.filter(is_room_option=True)
-            participant_order_detail = OrderLineBaseProduct.objects.get(
-                order_line=reservation.order_line,
-                option__in=room_options
-            )
+            try:
+                participant_order_detail = OrderLineBaseProduct.objects.get(
+                    order_line=reservation.order_line,
+                    option__in=room_options
+                )
+            except OrderLineBaseProduct.DoesNotExist:
+                # User has no options for the retreat
+                participant_data['room_option'] = 'NA'
+                participant_data['room_number'] = 'NA'
+                retreat_room_distribution[reservation.user.id] = \
+                    participant_data
+                continue
             current_option = OptionProduct.objects.get(
                 id=participant_order_detail.option_id,
             )
-
             if current_option.type == OptionProduct.METADATA_SHARED_ROOM:
                 participant_data['gender_preference'] = \
                     participant_order_detail.metadata[

--- a/retirement/tests/tests_model_Retreat.py
+++ b/retirement/tests/tests_model_Retreat.py
@@ -178,6 +178,11 @@ class RetreatTests(APITestCase):
             last_name='y',
             email='17@test.ca',
         )
+        user_18 = UserFactory(
+            first_name='x',
+            last_name='y',
+            email='18@test.ca',
+        )
 
         order_1 = OrderFactory(user=user_1)
         order_2 = OrderFactory(user=user_2)
@@ -196,6 +201,7 @@ class RetreatTests(APITestCase):
         order_15 = OrderFactory(user=user_15)
         order_16 = OrderFactory(user=user_16)
         order_17 = OrderFactory(user=user_17)
+        order_18 = OrderFactory(user=user_18)
 
         order_line_1 = OrderLineFactory(
             content_type=self.retreat_type,
@@ -281,6 +287,11 @@ class RetreatTests(APITestCase):
             content_type=self.retreat_type,
             object_id=self.retreat.id,
             order=order_17,
+        )
+        order_line_18 = OrderLineFactory(
+            content_type=self.retreat_type,
+            object_id=self.retreat.id,
+            order=order_18,
         )
 
         reservation_1 = ReservationFactory(
@@ -368,6 +379,11 @@ class RetreatTests(APITestCase):
             user=user_17,
             retreat=self.retreat,
             order_line=order_line_17,
+        )
+        reservation_18 = ReservationFactory(
+            user=user_18,
+            retreat=self.retreat,
+            order_line=order_line_18,
         )
 
         metadata_1 = {
@@ -691,14 +707,26 @@ class RetreatTests(APITestCase):
                 'share_with': '4@test.ca',
                 'room_number': 9,
                 'placed': True,
+            },
+            {
+                'id': user_18.id,
+                'first_name': 'x',
+                'last_name': 'y',
+                'email': '18@test.ca',
+                'room_option': 'NA',
+                'gender_preference': 'NA',
+                'share_with': 'NA',
+                'room_number': 'NA',
+                'placed': False,
             }
         ]
-        self.assertEqual(len(distribution), 16)
+        self.assertEqual(len(distribution), 17)
         room_set = set()
         for key, value in distribution.items():
             self.assertTrue(value in expected_distribution)
             room_set.add(value['room_number'])
-        self.assertEqual(len(room_set), 9)
+        self.assertEqual(len(room_set), 10)
+        self.assertTrue('NA' in room_set)
 
     def test_get_participants_emails(self):
         user = UserFactory(email='email@1')

--- a/retirement/views.py
+++ b/retirement/views.py
@@ -494,7 +494,8 @@ class RetreatViewSet(ExportMixin, viewsets.ModelViewSet):
     def export_participation(self, request, pk=None):
 
         retreat: Retreat = self.get_object()
-        export = generate_retreat_participation(request.user.id, retreat.id)
+        export = generate_retreat_participation.delay(
+            request.user.id, retreat.id)
         response = Response(
             status=status.HTTP_200_OK,
             data={


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Enhancement
| Tickets (_issues_) concerned               | 4995

---

##### What have you changed ?
Allow THV to export retreat with room options even if user hasnt selected options

##### How did you change it ?
Set 'NA' values when options aren't found

##### Is there a special consideration?
Correct a small issue where call was not a task (delay)

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [x] My additions are I18N
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
 -  [x] I added or modified the documentation