### PR TITLE
correct response by matching existing pattern #rm4947

### DIFF
--- a/retirement/exports.py
+++ b/retirement/exports.py
@@ -11,7 +11,6 @@ from django.utils import timezone
 from django.conf import settings
 
 from blitz_api.models import ExportMedia
-from blitz_api.serializers import ExportMediaSerializer
 from retirement.models import Retreat
 
 LOCAL_TIMEZONE = pytz.timezone(settings.TIME_ZONE)
@@ -134,4 +133,4 @@ def generate_retreat_participation(
         ContentFile(output_stream.getvalue().encode()))
     new_export.send_confirmation_email()
 
-    return ExportMediaSerializer(new_export)
+    return new_export

--- a/retirement/views.py
+++ b/retirement/views.py
@@ -496,10 +496,14 @@ class RetreatViewSet(ExportMixin, viewsets.ModelViewSet):
         retreat: Retreat = self.get_object()
         export = generate_retreat_participation.delay(
             request.user.id, retreat.id)
+        export_url = ExportMediaSerializer(
+            export,
+            context={'request': request}
+        ).data.get('file')
         response = Response(
             status=status.HTTP_200_OK,
             data={
-                'file_url': export.data.get('file')
+                'file_url': export_url
             }
         )
 


### PR DESCRIPTION
correct error : `HyperlinkedIdentityField` requires the request in the serializer context. Add `context={'request': request}` when instantiating the serializer.