### PR TITLE
fix remaining quantity exclude

### DIFF
--- a/store/models.py
+++ b/store/models.py
@@ -615,7 +615,8 @@ class OptionProduct(BaseProduct):
             ordered_quantity = OrderLineBaseProduct.objects.filter(
                 option=self,
             ).exclude(
-                order_line__in=refunded_order_lines,
+                order_line__in=[
+                    x for x in refunded_order_lines if x is not None],
             ).aggregate(
                 sum=Sum('quantity'),
             )['sum']


### PR DESCRIPTION
Presence of None in refunded_order_lines caused issue (see https://stackoverflow.com/questions/47058497/django-queryset-exclude-why-are-all-excluded)
