### PR TITLE
Feature refunded orderlines #rm4984

### DIFF
--- a/store/serializers.py
+++ b/store/serializers.py
@@ -1172,6 +1172,7 @@ class CouponSerializer(serializers.HyperlinkedModelSerializer):
 
             usages = list()
             for line in OrderLine.objects.filter(coupon=instance):
+                is_refunded = Refund.objects.filter(orderline=line).exists()
                 usages.append(
                     {
                         'date': line.order.transaction_date,
@@ -1191,6 +1192,7 @@ class CouponSerializer(serializers.HyperlinkedModelSerializer):
                             },
                         ).data,
                         'product_name': line.content_object.name,
+                        'orderline_refunded': is_refunded,
                     }
                 )
 


### PR DESCRIPTION
Front end will need to filter by orderline_refunded for display
Note: while fixing the issue of coupon utilisation view, several questions rose and will need answers and probably tickets

Au sujet des echanges de retraite:
La logique de choix (retraite de meme type/meme prix) est elle correcte ? (normalement oui)
Si l'echange se fait, l'orderline doit elle pointer sur la nouvelle retraite (actuellement pas le cas, ce qui veut dire que si un coupon est utilise, il pointera sur l'ancienne retraite)
Pour savoir si une retraite a le meme prix, on regarde le prix de base, sans compter les options. Ex: une retraite a 10CAD prise avec une option a 30CAD (soit 40CAD) est echangeable avec une retraite a 10CAD mais pas avec une retraite a 40CAD: est ce le comportement souhaite ?
Si on echange pour une retraite avec option, on ne demande jamais de prendre les nouvelles options:  est ce le comportement souhaite ? Sinon, comment gerer le conflit avec le premier point (meme prix) ?
Si un coupon est utilise sur la premiere retraite, ce coupon peut il etre utilise sur la retraite choisie pour l'echange ? Si oui, a quelles conditions ?