### PR TITLE
Feature list retreat type automated email #rm5000

### DIFF
--- a/blitz_api/testing_tools.py
+++ b/blitz_api/testing_tools.py
@@ -56,6 +56,16 @@ RETREAT_TYPE_ATTRIBUTES = [
     'context_for_welcome_message',
 ]
 
+AUTOMATIC_EMAIL_ATTRIBUTES = [
+    'id',
+    'url',
+    'minutes_delta',
+    'time_base',
+    'template_id',
+    'context',
+    'retreat_type',
+]
+
 
 class CustomAPITestCase(APITestCase):
     ATTRIBUTES = []

--- a/retirement/serializers.py
+++ b/retirement/serializers.py
@@ -156,6 +156,9 @@ class AutomaticEmailSerializer(serializers.HyperlinkedModelSerializer):
             'url': {
                 'view_name': 'retreat:automaticemail-detail',
             },
+            'retreat_type': {
+                'view_name': 'retreat:retreattype-detail',
+            },
         }
 
 

--- a/retirement/tests/tests_viewset_AutomaticEmail.py
+++ b/retirement/tests/tests_viewset_AutomaticEmail.py
@@ -1,0 +1,214 @@
+import json
+
+import pytz
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from blitz_api.factories import (
+    AdminFactory,
+    UserFactory,
+)
+from blitz_api import testing_tools
+from blitz_api.testing_tools import CustomAPITestCase
+
+from retirement.models import (
+    RetreatType,
+    AutomaticEmail,
+)
+User = get_user_model()
+
+LOCAL_TIMEZONE = pytz.timezone(settings.TIME_ZONE)
+
+
+class AutomaticEmailTests(CustomAPITestCase):
+    ATTRIBUTES = testing_tools.AUTOMATIC_EMAIL_ATTRIBUTES
+
+    @classmethod
+    def setUpClass(cls):
+        super(AutomaticEmailTests, cls).setUpClass()
+        cls.client = APIClient()
+        cls.user = UserFactory()
+        cls.admin = AdminFactory()
+
+    def setUp(self):
+        self.retreatType_1 = RetreatType.objects.create(
+            name="Type 1",
+            minutes_before_display_link=10,
+            number_of_tomatoes=4,
+        )
+        self.retreatType_2 = RetreatType.objects.create(
+            name="Type 1",
+            minutes_before_display_link=10,
+            number_of_tomatoes=4,
+        )
+        self.auto_email_1 = AutomaticEmail.objects.create(
+            minutes_delta=1,
+            time_base=AutomaticEmail.TIME_BASE_AFTER_END,
+            template_id='1',
+            context='Auto email 1 context',
+            retreat_type=self.retreatType_1
+        )
+        self.auto_email_2 = AutomaticEmail.objects.create(
+            minutes_delta=1,
+            time_base=AutomaticEmail.TIME_BASE_AFTER_END,
+            template_id='1',
+            context='Auto email 1 context',
+            retreat_type=self.retreatType_1
+        )
+        self.auto_email_3 = AutomaticEmail.objects.create(
+            minutes_delta=1,
+            time_base=AutomaticEmail.TIME_BASE_AFTER_END,
+            template_id='1',
+            context='Auto email 1 context',
+            retreat_type=self.retreatType_2
+        )
+
+    def test_create_as_user(self):
+        """
+        Ensure we can't create an automatic email as user
+        """
+        self.client.force_authenticate(user=self.user)
+
+        data = {
+            'minutes_delta': 1,
+            'time_base': AutomaticEmail.TIME_BASE_AFTER_END,
+            'template_id': '1',
+            'context': 'My user context',
+            'retreat_type': reverse(
+                'retreat:automaticemail-detail', args=[self.retreatType_1.id]),
+        }
+
+        response = self.client.post(
+            reverse('retreat:automaticemail-list'),
+            data,
+            format='json',
+        )
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_403_FORBIDDEN,
+            response.content
+        )
+
+    def test_create_by_admin(self):
+        """
+        Ensure admin can create an automatic email.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        data = {
+            'minutes_delta': 1,
+            'time_base': AutomaticEmail.TIME_BASE_AFTER_END,
+            'template_id': '1',
+            'context': 'My user context',
+            'retreat_type': reverse(
+                'retreat:retreattype-detail', args=[self.retreatType_1.id]),
+        }
+
+        response = self.client.post(
+            reverse('retreat:automaticemail-list'),
+            data,
+            format='json',
+        )
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_201_CREATED,
+            response.content
+        )
+        content = json.loads(response.content)
+        self.check_attributes(content)
+
+    def test_update_by_admin(self):
+        """
+        Ensure admin can update an automatic email.
+        """
+        self.client.force_authenticate(user=self.admin)
+
+        data = {
+            'minutes_delta': 2,
+            'time_base': AutomaticEmail.TIME_BASE_BEFORE_START,
+            'template_id': '2',
+            'context': 'Updated context',
+            'retreat_type': reverse(
+                'retreat:retreattype-detail',
+                args=[self.retreatType_2.id]),
+        }
+
+        response = self.client.patch(
+            reverse(
+                'retreat:automaticemail-detail',
+                args=[self.auto_email_1.id]
+            ),
+            data,
+        )
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            response.content)
+        updated_email = AutomaticEmail.objects.get(pk=self.auto_email_1.id)
+        self.assertEqual(updated_email.minutes_delta, data['minutes_delta'])
+        self.assertEqual(updated_email.time_base, data['time_base'])
+        self.assertEqual(updated_email.template_id, data['template_id'])
+        self.assertEqual(updated_email.context, data['context'])
+        self.assertEqual(updated_email.retreat_type.id, self.retreatType_2.id)
+
+    def test_update_by_user(self):
+        """
+        Ensure user can't update a retreat type.
+        """
+        self.client.force_authenticate(user=self.user)
+
+        data = {
+            'minutes_delta': 2,
+            'time_base': AutomaticEmail.TIME_BASE_BEFORE_START,
+            'template_id': '2',
+            'context': 'Updated context',
+            'retreat_type': reverse(
+                'retreat:automaticemail-detail', args=[self.retreatType_2.id]),
+        }
+
+        response = self.client.patch(
+            reverse(
+                'retreat:automaticemail-detail',
+                args=[self.auto_email_1.id]
+            ),
+            data,
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_by_user(self):
+        """
+        Test that user can list auto email
+        """
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(
+            reverse('retreat:automaticemail-list'),
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        content = json.loads(response.content)
+        self.assertEqual(len(content['results']), 3)
+        self.check_attributes(content['results'][0])
+
+    def test_list_by_retreat_type_by_admin(self):
+        """
+        Test that admin can list auto email by retreat type
+        """
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(
+            reverse('retreat:automaticemail-list'),
+            {
+                'retreat_type': self.retreatType_1.id
+            },
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        content = json.loads(response.content)
+        self.assertEqual(len(content['results']), 2)
+        self.check_attributes(content['results'][0])


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Features
| Tickets (_issues_) concerned               | 5000

---

##### What have you changed ?
Formalize usage of auto-email (create, update, list with filter)

##### How did you change it ?
Code was already there, except for a missing extra_kwargs in serializer. I added all tests to make sure everything works.

##### Is there a special consideration?
Front will need to make one call to get all auto email link to a retreat type.

Verification :
 -  [ ] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [ ] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [ ] My additions are I18N
 -  [ ] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 -  [ ] I added or modified the documentation