### PR TITLE
use content type to access foreign model and avoid Attribute Error

### DIFF
--- a/store/migrations/0048_autopopulate_orderline_total_cost.py
+++ b/store/migrations/0048_autopopulate_orderline_total_cost.py
@@ -4,14 +4,17 @@ from django.db import migrations
 
 
 def populate_orderline_total_cost(apps, schema_editor):
+    from django.contrib.contenttypes.models import ContentType
     OrderLine = apps.get_model('store', 'OrderLine')
 
     order_lines = OrderLine.objects.all()
     for line in order_lines:
         # total_cost is the value of old cost.
         line.total_cost = line.cost
-        base = line.content_object
-        base_price = base.price if base.price else 0
+        ct = ContentType.objects.get(model=line.content_type.model,
+                                     app_label=line.content_type.app_label)
+        content_object = ct.get_object_for_this_type(pk=line.object_id)
+        base_price = content_object.price if content_object.price else 0
         coupon_value = line.coupon_real_value if line.coupon_real_value else 0
         line.cost = base_price - coupon_value
         # No need to apply coupon on total_cost for it copies old cost


### PR DESCRIPTION
Implement SO solution to avoid 
File "/home/ubuntu/Blitz-API/store/migrations/0048_autopopulate_orderline_total_cost.py", line 13, in populate_orderline_total_cost
    base = line.content_object
AttributeError: 'OrderLine' object has no attribute 'content_object'

https://stackoverflow.com/questions/36256324/why-genericrelation-fields-does-not-work-in-data-migrationsdjango