### PR TITLE
fix coupon application on retreat type #rm5453

### DIFF
--- a/store/serializers.py
+++ b/store/serializers.py
@@ -47,8 +47,7 @@ from .services import (charge_payment,
                        create_external_payment_profile,
                        create_external_card,
                        get_external_cards,
-                       PAYSAFE_CARD_TYPE,
-                       validate_coupon_for_order, )
+                       PAYSAFE_CARD_TYPE,)
 
 User = get_user_model()
 


### PR DESCRIPTION
Fix usage on coupon for retreat type. Needed a work around since we don't have GenericRelation implemented for reverse querying

note for usage of `|` : https://stackoverflow.com/questions/1125844/how-to-merge-2-django-querysets-in-one-and-make-a-select-distinct